### PR TITLE
Add 24/7 scheduling assistant call button

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -201,8 +201,9 @@
   #site-footer.ftr .ftr-cta .ftr-container{
     flex-direction:column; align-items:stretch; text-align:center;
   }
-  #site-footer.ftr .ftr-cta-actions{ display:flex; gap:.6rem; width:100%; }
+  #site-footer.ftr .ftr-cta-actions{ display:flex; flex-wrap:wrap; gap:.6rem; width:100%; }
   #site-footer.ftr .ftr-cta-actions .ftr-btn{ flex:1; width:100%; }
+  #site-footer.ftr .ftr-cta-actions .ftr-btn-assistant{ flex-basis:100%; }
   #site-footer.ftr .ftr-cta-text{ font-size:1rem; }
 
   /* bigger touch targets */

--- a/js/footer.js
+++ b/js/footer.js
@@ -1,23 +1,19 @@
 // current year in footer
 (()=>{ const y=document.getElementById('year'); if(y) y.textContent=new Date().getFullYear(); })();
 
-// JobNimbus AI chat button
+// JobNimbus AI chat and scheduling-assistant buttons
 (() => {
-  const BUTTON_SELECTOR = '[data-zenith-jobnimbus-chat]';
+  const CHAT_SELECTOR = '[data-zenith-jobnimbus-chat]';
+  const CALL_SELECTOR = '[data-zenith-jobnimbus-call]';
   const SCRIPT_SELECTOR = 'script[data-zenith-jobnimbus-widget]';
+  let footerObserver;
 
-  function installChatButton() {
-    if (!document.body || document.querySelector(BUTTON_SELECTOR)) return;
-
-    const button = document.createElement('button');
-    button.className = 'vidaButtonV2';
+  function setSharedAttributes(button) {
+    button.classList.add('vidaButtonV2');
     button.setAttribute('data-vida-button-v2', '');
-    button.setAttribute('data-zenith-jobnimbus-chat', '');
     button.setAttribute('data-target', 'acct1770668469919');
     button.setAttribute('data-number', '+17606421299');
     button.setAttribute('data-domain', 'https://marketinghub.jobnimbus.com');
-    button.setAttribute('data-type', 'chat');
-    button.setAttribute('data-text', 'Ask a Roofing Question');
     button.setAttribute('data-color', '#123B5D');
     button.setAttribute('data-text-color', '#FFFFFF');
     button.setAttribute('data-size', 'medium');
@@ -26,31 +22,88 @@
     button.setAttribute('data-height', '44');
     button.setAttribute('data-padding-x', '16');
     button.setAttribute('data-border-radius', '10');
-    button.setAttribute('data-icon', 'chat');
     button.setAttribute('data-icon-only', 'false');
     button.setAttribute('data-icon-size', '16');
     button.setAttribute('data-icon-position', 'left');
-    button.setAttribute('data-floating', 'true');
     button.setAttribute('data-position', 'bottom-right');
     button.setAttribute('data-offset-x', '24');
     button.setAttribute('data-offset-y', '24');
     button.style.visibility = 'hidden';
-    button.textContent = 'Ask a Roofing Question';
-    document.body.appendChild(button);
-
-    if (!document.querySelector(SCRIPT_SELECTOR)) {
-      const script = document.createElement('script');
-      script.src = 'https://marketinghub.jobnimbus.com/embed/button/v2/script.js';
-      script.defer = true;
-      script.setAttribute('data-domain', 'https://marketinghub.jobnimbus.com');
-      script.setAttribute('data-zenith-jobnimbus-widget', '');
-      document.head.appendChild(script);
-    }
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', installChatButton, { once: true });
-  } else {
+  function installChatButton() {
+    if (!document.body || document.querySelector(CHAT_SELECTOR)) return;
+
+    const button = document.createElement('button');
+    setSharedAttributes(button);
+    button.setAttribute('data-zenith-jobnimbus-chat', '');
+    button.setAttribute('data-type', 'chat');
+    button.setAttribute('data-text', 'Ask a Roofing Question');
+    button.setAttribute('data-icon', 'chat');
+    button.setAttribute('data-floating', 'true');
+    button.textContent = 'Ask a Roofing Question';
+    document.body.appendChild(button);
+  }
+
+  function installCallButton() {
+    if (document.querySelector(CALL_SELECTOR)) return true;
+
+    const actions = document.querySelector('#site-footer .ftr-cta-actions');
+    if (!actions) return false;
+
+    const button = document.createElement('button');
+    setSharedAttributes(button);
+    button.classList.add('ftr-btn', 'ftr-btn-ghost', 'ftr-btn-assistant');
+    button.setAttribute('data-zenith-jobnimbus-call', '');
+    button.setAttribute('data-type', 'call');
+    button.setAttribute('data-text', 'Call Our 24/7 Scheduling Assistant');
+    button.setAttribute('data-icon', 'phone');
+    button.setAttribute('data-floating', 'false');
+    button.setAttribute('aria-label', 'Call the Zenith Roofing 24/7 scheduling assistant');
+    button.textContent = 'Call Our 24/7 Scheduling Assistant';
+    actions.appendChild(button);
+    return true;
+  }
+
+  function loadWidgetScript() {
+    if (document.querySelector(SCRIPT_SELECTOR)) return;
+
+    const script = document.createElement('script');
+    script.src = 'https://marketinghub.jobnimbus.com/embed/button/v2/script.js';
+    script.defer = true;
+    script.setAttribute('data-domain', 'https://marketinghub.jobnimbus.com');
+    script.setAttribute('data-zenith-jobnimbus-widget', '');
+    document.head.appendChild(script);
+  }
+
+  function installJobNimbusWidgets() {
     installChatButton();
+
+    if (!installCallButton()) return;
+
+    if (footerObserver) {
+      footerObserver.disconnect();
+      footerObserver = null;
+    }
+    loadWidgetScript();
+  }
+
+  // The footer is injected asynchronously on this site. Expose the initializer
+  // for the include loader and watch as a fallback on pages with another loader.
+  window.initFooter = installJobNimbusWidgets;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', installJobNimbusWidgets, { once: true });
+  } else {
+    installJobNimbusWidgets();
+  }
+
+  if (!document.querySelector('#site-footer .ftr-cta-actions')) {
+    footerObserver = new MutationObserver(() => {
+      if (document.querySelector('#site-footer .ftr-cta-actions')) {
+        installJobNimbusWidgets();
+      }
+    });
+    footerObserver.observe(document.documentElement, { childList: true, subtree: true });
   }
 })();


### PR DESCRIPTION
Adds the JobNimbus AI call button as a secondary, non-floating action in the shared footer contact strip.

- Keeps the existing 858-900-6163 phone link unchanged
- Keeps the floating “Ask a Roofing Question” chat button
- Adds “Call Our 24/7 Scheduling Assistant” using +1 760-642-1299
- Loads the JobNimbus script only once, after both widgets are available
- Makes the assistant action full-width on mobile to avoid cramped buttons

This PR does not change or replace the main business phone number.