### PR TITLE
Remove photo upload and lead email delivery

### DIFF
--- a/components/hero-section.html
+++ b/components/hero-section.html
@@ -101,11 +101,7 @@
 
       <!-- Row 5 -->
       <div class="form-row">
-        <div class="form-group form-col-4">
-          <label for="photos" class="sr-only">Upload Photos</label>
-          <input type="file" id="photos" name="photos" accept="image/*" multiple />
-        </div>
-        <div class="form-group form-col-4">
+        <div class="form-group form-col-6">
           <label for="serviceType" class="sr-only">Service Type*</label>
           <select id="serviceType" name="service_type" required>
             <option value="" selected disabled hidden>Service Type*</option>
@@ -118,7 +114,7 @@
             <option>Other</option>
           </select>
         </div>
-        <div class="form-group form-col-4">
+        <div class="form-group form-col-6">
           <label for="referral" class="sr-only">How did you hear about us?*</label>
           <select id="referral" name="referral_source" required>
                 <option value="" selected disabled hidden>How did you hear about us?*</option>

--- a/netlify/functions/jn-create-lead.js
+++ b/netlify/functions/jn-create-lead.js
@@ -82,10 +82,7 @@ exports.handler = async (event) => {
     const {
       JN_API_KEY,
       JN_CONTACT_ENDPOINT,
-      RECAPTCHA_SECRET,
-      SENDGRID_API_KEY,
-      LEAD_NOTIFY_FROM,
-      LEAD_NOTIFY_TO
+      RECAPTCHA_SECRET
     } = process.env;
 
     if (!JN_API_KEY || !JN_CONTACT_ENDPOINT) {
@@ -286,44 +283,6 @@ exports.handler = async (event) => {
           message: (jnText || '').slice(0, 800)
         })
       };
-    }
-
-    // ---- Optional: SendGrid notify ----
-    if (SENDGRID_API_KEY && LEAD_NOTIFY_FROM && LEAD_NOTIFY_TO) {
-      try {
-        const addrForEmail = [payloadBase.address1, payloadBase.address2, payloadBase.city, payloadBase.state, payloadBase.postal_code]
-          .filter(Boolean).join(', ') || '(none)';
-
-        const message = [
-          `<strong>New Website Lead</strong>`,
-          `Name: ${displayName}`,
-          `Email: ${email || '(none)'}`,
-          `Phone: ${formattedPhone}`,
-          `Address: ${addrForEmail}`,
-          `Service: ${payloadBase.service_type || '(none)'}`,
-          `Referral: ${payloadBase.lead_source || '(none)'}`,
-          `Page: ${data.page || '(unknown)'}`,
-          '',
-          `Notes:`,
-          (data.description || '(none)')
-        ].join('<br>');
-
-        await fetch('https://api.sendgrid.com/v3/mail/send', {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${SENDGRID_API_KEY}`,
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({
-            personalizations: [{ to: [{ email: LEAD_NOTIFY_TO }] }],
-            from: { email: LEAD_NOTIFY_FROM, name: 'Zenith Roofing Website' },
-            subject: 'New Website Lead',
-            content: [{ type: 'text/html', value: message }]
-          })
-        });
-      } catch (e) {
-        console.error('SendGrid error:', e);
-      }
     }
 
     // Pass JN response through on success


### PR DESCRIPTION
Removes the optional photo upload control from the shared homepage estimate form and removes the SendGrid lead-email notification path from the shared JobNimbus function.

Preserved unchanged:
- required-field validation and red invalid-state styling
- phone formatting and ZIP/city behavior
- JobNimbus contact/address/lead-source mapping
- reCAPTCHA verification
- Google Ads conversion tracking

The two remaining dropdowns on the homepage form now split the row evenly.