### PR TITLE
Fix lead form submission handler

### DIFF
--- a/js/hero.js
+++ b/js/hero.js
@@ -55,7 +55,8 @@
     // Required fields you collect server-side
     const requiredIds = [
       'firstName','lastName','phone','email',
-      'streetAddress','city','state','zip'
+      'streetAddress','city','state','zip',
+      'serviceType','referral','description'
     ];
 
     for (const id of requiredIds) {
@@ -175,6 +176,9 @@
     if (window.grecaptcha && typeof window.grecaptcha.getResponse === 'function') {
       if (typeof window._recaptchaWidgetId !== 'undefined') {
         token = window.grecaptcha.getResponse(window._recaptchaWidgetId) || '';
+      } else {
+        // Support Google's automatic render path as well as our explicit render.
+        token = window.grecaptcha.getResponse() || '';
       }
     }
     if (!token) {
@@ -263,6 +267,8 @@
   function attachBehaviors() {
     const form = document.getElementById('estimate-form');
     if (!form) return;
+    if (form.dataset.zenithLeadBound === 'true') return;
+    form.dataset.zenithLeadBound = 'true';
 
     // Phone mask
     const phone = $('#phone', form);
@@ -299,113 +305,3 @@
     attachBehaviors();
   }
 })();
-// ... your existing hero.js above ...
-
-  // ---------- Boot ----------
-  function attachBehaviors() {
-    const form = document.getElementById('estimate-form');
-    if (!form) return;
-
-    // NEW: apply per-page config if provided
-    applyFormConfig(form); // NEW
-
-    // Phone mask
-    const phone = $('#phone', form);
-    if (phone) phone.addEventListener('input', maskPhoneInput);
-
-    // ZIP → City/State autofill
-    const zipEl = $('#zip', form);
-    if (zipEl) {
-      const trigger = debounce(() => {
-        const v = (zipEl.value || '').trim().slice(0, 5);
-        if (/^\d{5}$/.test(v)) fillCityStateFromZip(v, form);
-      }, 350);
-      zipEl.addEventListener('input', trigger);
-      zipEl.addEventListener('blur', () => {
-        const v = (zipEl.value || '').trim().slice(0, 5);
-        if (/^\d{5}$/.test(v)) fillCityStateFromZip(v, form);
-      });
-    }
-
-    // Try to render reCAPTCHA now (and again on first focus)
-    tryRenderRecaptchaWithRetries();
-    form.addEventListener('focusin', renderRecaptchaIfPossible, { once: true });
-
-    // Submit wiring
-    form.addEventListener('submit', submitHandler);
-  }
-
-  // NEW: universal form config (title, subtitle, lock/preselect service, placeholders, hidden fields)
-  function applyFormConfig(form) {
-    const cfg = window.ESTIMATE_FORM_CONFIG || {};
-    const block = form.closest('.estimate-form-block') || document;
-
-    // Title / subtitle
-    if (cfg.title) {
-      const h1 = block.querySelector('.form-title');
-      if (h1) h1.textContent = cfg.title;
-    }
-    if (cfg.subtitle) {
-      const sub = block.querySelector('.form-subtitle');
-      if (sub) sub.textContent = cfg.subtitle;
-    }
-
-    // Description placeholder
-    if (cfg.descriptionPlaceholder) {
-      const desc = form.querySelector('#description');
-      if (desc) desc.placeholder = cfg.descriptionPlaceholder;
-    }
-
-    // Referral preselect
-    if (cfg.referralPreselect) {
-      const ref = form.querySelector('#referral');
-      if (ref) {
-        [...ref.options].forEach(o => {
-          if (o.text.trim().toLowerCase() === String(cfg.referralPreselect).trim().toLowerCase()) {
-            o.selected = true;
-          }
-        });
-      }
-    }
-
-    // Service lock OR preselect
-    const serviceWrap = form.querySelector('.service-select-wrap');
-    const select = form.querySelector('#serviceType');
-
-    if (cfg.lockService && serviceWrap) {
-      // Replace the select with a hidden field + a visible pill
-      const lockedVal = String(cfg.lockService);
-      const hidden = document.createElement('input');
-      hidden.type = 'hidden';
-      hidden.name = 'service_type';
-      hidden.value = lockedVal;
-
-      const pill = document.createElement('div');
-      pill.setAttribute('aria-label', 'Selected service');
-      pill.style.cssText = 'display:flex;align-items:center;gap:.5rem;padding:.9rem .95rem;border:1px solid var(--zenith-border);border-radius:10px;background:#f8fafc;color:#0f172a;font-weight:600;';
-      pill.textContent = lockedVal;
-
-      serviceWrap.innerHTML = '';
-      serviceWrap.appendChild(pill);
-      serviceWrap.appendChild(hidden);
-    } else if (cfg.preselectService && select) {
-      [...select.options].forEach(o => {
-        if (o.text.trim().toLowerCase() === String(cfg.preselectService).trim().toLowerCase()) {
-          o.selected = true;
-        }
-      });
-    }
-
-    // Extra hidden fields (e.g., campaign, page tag)
-    if (cfg.hiddenFields && typeof cfg.hiddenFields === 'object') {
-      Object.entries(cfg.hiddenFields).forEach(([name, val]) => {
-        const h = document.createElement('input');
-        h.type = 'hidden';
-        h.name = name;
-        h.value = String(val);
-        form.appendChild(h);
-      });
-    }
-  }
-
-// ... rest of your hero.js remains the same ...


### PR DESCRIPTION
## What changed

- removes the orphaned duplicate form setup block from `js/hero.js`
- makes form binding idempotent so dynamic hero injection cannot attach duplicate submit handlers
- supports both explicitly rendered and automatically rendered reCAPTCHA widgets
- validates service type, referral source, and description before calling the Netlify function

## Root cause

The homepage assembles the hero dynamically while the form script can be loaded and initialized more than once. The script also contained a second stale copy of its boot logic outside the main module. This created inconsistent reCAPTCHA and submit-handler state.

## Validation

- `node --check js/hero.js`
- `git diff --check`
- live-site inspection confirmed the form and reCAPTCHA render; endpoint debug request returned successfully
- regression assertions confirm only one `attachBehaviors` implementation remains and the binding guard is present