### PR TITLE
Fix financing and roof replacement reCAPTCHA

### DIFF
--- a/financing/index.html
+++ b/financing/index.html
@@ -265,7 +265,7 @@
               <div class="finance-form-field full"><label for="fin-description">Tell us about the roof or project *</label><textarea id="fin-description" name="description" placeholder="Leaks, roof type, approximate age, timing, or anything else we should know" required></textarea></div>
             </div>
             <input type="hidden" name="state" value="CA">
-            <div class="g-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5" style="margin-top:18px"></div>
+            <div id="financing-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5" style="margin-top:18px"></div>
             <button class="fin-btn fin-btn-primary finance-form-submit" type="submit">Request My Roofing Estimate</button>
             <div id="financing-form-status" class="finance-form-status" role="status" aria-live="polite"></div>
             <p class="form-privacy">Your information is used to respond to your roofing request. Submitting this form does not apply for credit. Financing applications are completed securely through Wisetack.</p>
@@ -425,6 +425,12 @@
         zipInput.addEventListener('blur',populateCityFromZip);
       }
     });
+    let financingRecaptchaId=null;
+    window.onFinancingRecaptchaLoaded=function(){
+      const holder=document.getElementById('financing-recaptcha');
+      if(!holder||typeof grecaptcha==='undefined'||financingRecaptchaId!==null)return;
+      financingRecaptchaId=grecaptcha.render(holder,{sitekey:holder.dataset.sitekey});
+    };
     document.addEventListener('submit',async function(e){
       const form=e.target.closest('#financing-lead-form');
       if(!form)return;
@@ -434,7 +440,8 @@
       status.className='finance-form-status';
       status.textContent='';
       if(!form.checkValidity()){form.reportValidity();status.classList.add('error');status.textContent='Please complete the required fields highlighted in red.';return;}
-      const captcha=typeof grecaptcha!=='undefined'?grecaptcha.getResponse():'';
+      const captcha=typeof grecaptcha!=='undefined'&&financingRecaptchaId!==null
+        ?grecaptcha.getResponse(financingRecaptchaId):'';
       if(!captcha){status.classList.add('error');status.textContent='Please complete the “I’m not a robot” check.';return;}
       const fd=new FormData(form);
       const params=new URLSearchParams(location.search);
@@ -478,7 +485,7 @@
         window.dataLayer=window.dataLayer||[];
         window.dataLayer.push({event:'financing_estimate_lead',service_type:payload.service_type,lead_source:payload.referral_source});
         form.reset();form.classList.remove('was-validated');
-        if(typeof grecaptcha!=='undefined')grecaptcha.reset();
+        if(typeof grecaptcha!=='undefined'&&financingRecaptchaId!==null)grecaptcha.reset(financingRecaptchaId);
       }catch(err){
         status.classList.add('error');
         status.textContent=err.message||'We could not send your request. Please call 858-900-6163.';
@@ -492,7 +499,7 @@
       if(typeof gtag==='function')gtag('event','wisetack_prequalification_click',{event_category:'Financing',event_label:location.pathname,transport_type:'beacon'});
     });
   </script>
-  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+  <script src="https://www.google.com/recaptcha/api.js?onload=onFinancingRecaptchaLoaded&render=explicit" async defer></script>
   <script src="/js/header.js" defer></script>
   <script src="/js/footer.js" defer></script>
 </body>

--- a/roof-replacement-landing.js
+++ b/roof-replacement-landing.js
@@ -4,6 +4,15 @@
   const form = document.getElementById("ad-estimate-form");
   if (!form) return;
 
+  let recaptchaId = null;
+  window.onRoofReplacementRecaptchaLoaded = () => {
+    const holder = document.getElementById("roof-replacement-recaptcha");
+    if (!holder || !window.grecaptcha || recaptchaId !== null) return;
+    recaptchaId = window.grecaptcha.render(holder, {
+      sitekey: holder.dataset.sitekey
+    });
+  };
+
   const message = form.querySelector(".form-message");
   const button = form.querySelector('button[type="submit"]');
   const params = new URLSearchParams(location.search);
@@ -42,7 +51,9 @@
 
     let token = "";
     if (window.grecaptcha && typeof window.grecaptcha.getResponse === "function") {
-      token = window.grecaptcha.getResponse() || "";
+      token = recaptchaId !== null
+        ? window.grecaptcha.getResponse(recaptchaId) || ""
+        : "";
     }
     if (!token) {
       setMessage("Please complete the reCAPTCHA before submitting.", "error");
@@ -98,7 +109,9 @@
       }
       form.reset();
       form.classList.remove("has-errors");
-      if (window.grecaptcha) window.grecaptcha.reset();
+      if (window.grecaptcha && recaptchaId !== null) {
+        window.grecaptcha.reset(recaptchaId);
+      }
       setMessage("Thank you. Your request was sent to Zenith Roofing Services.", "success");
     } catch (error) {
       console.error(error);

--- a/roof-replacement.html
+++ b/roof-replacement.html
@@ -94,7 +94,7 @@
             <input type="hidden" name="service_type" value="Roof Replacement">
             <input type="hidden" name="referral_source" value="Google Ads">
             <input type="hidden" name="landing_page" value="/roof-replacement/">
-            <div class="g-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5"></div>
+            <div id="roof-replacement-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5"></div>
             <div class="form-message" role="status" aria-live="polite"></div>
             <button class="button button-primary submit-button" type="submit">Request My Free Estimate</button>
             <p class="privacy-note">Your information is used only to respond to your roofing request.</p>
@@ -194,7 +194,7 @@
   </footer>
 
   <a class="mobile-call-bar track-call" href="tel:6194941122">Call Zenith · 619-494-1122</a>
-  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-  <script src="/roof-replacement-landing.js" defer></script>
+  <script src="/roof-replacement-landing.js"></script>
+  <script src="https://www.google.com/recaptcha/api.js?onload=onRoofReplacementRecaptchaLoaded&render=explicit" async defer></script>
 </body>
 </html>

--- a/roof-replacement/index.html
+++ b/roof-replacement/index.html
@@ -94,7 +94,7 @@
             <input type="hidden" name="service_type" value="Roof Replacement">
             <input type="hidden" name="referral_source" value="Google Ads">
             <input type="hidden" name="landing_page" value="/roof-replacement/">
-            <div class="g-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5"></div>
+            <div id="roof-replacement-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5"></div>
             <div class="form-message" role="status" aria-live="polite"></div>
             <button class="button button-primary submit-button" type="submit">Request My Free Estimate</button>
             <p class="privacy-note">Your information is used only to respond to your roofing request.</p>
@@ -194,7 +194,7 @@
   </footer>
 
   <a class="mobile-call-bar track-call" href="tel:6194941122">Call Zenith · 619-494-1122</a>
-  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-  <script src="/roof-replacement/landing.js" defer></script>
+  <script src="/roof-replacement/landing.js"></script>
+  <script src="https://www.google.com/recaptcha/api.js?onload=onRoofReplacementRecaptchaLoaded&render=explicit" async defer></script>
 </body>
 </html>

--- a/roof-replacement/landing.js
+++ b/roof-replacement/landing.js
@@ -4,6 +4,15 @@
   const form = document.getElementById("ad-estimate-form");
   if (!form) return;
 
+  let recaptchaId = null;
+  window.onRoofReplacementRecaptchaLoaded = () => {
+    const holder = document.getElementById("roof-replacement-recaptcha");
+    if (!holder || !window.grecaptcha || recaptchaId !== null) return;
+    recaptchaId = window.grecaptcha.render(holder, {
+      sitekey: holder.dataset.sitekey
+    });
+  };
+
   const message = form.querySelector(".form-message");
   const button = form.querySelector('button[type="submit"]');
   const params = new URLSearchParams(location.search);
@@ -41,7 +50,9 @@
 
     let token = "";
     if (window.grecaptcha && typeof window.grecaptcha.getResponse === "function") {
-      token = window.grecaptcha.getResponse() || "";
+      token = recaptchaId !== null
+        ? window.grecaptcha.getResponse(recaptchaId) || ""
+        : "";
     }
     if (!token) {
       setMessage("Please complete the reCAPTCHA before submitting.", "error");
@@ -91,7 +102,9 @@
         keyword: fd.get("utm_term") || ""
       });
       form.reset();
-      if (window.grecaptcha) window.grecaptcha.reset();
+      if (window.grecaptcha && recaptchaId !== null) {
+        window.grecaptcha.reset(recaptchaId);
+      }
       setMessage("Thank you. Your request was sent to Zenith Roofing Services.", "success");
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
## What changed

- renders reCAPTCHA explicitly on the financing and roof-replacement forms
- stores each widget ID and reads/resets the response from that exact widget
- uses the same working production site key as the homepage
- removes the timing ambiguity from automatic widget discovery

## Root cause

The homepage form worked after JobNimbus authentication was fixed, while the financing and roof-replacement forms still failed reCAPTCHA. Those pages used separate scripts that called `grecaptcha.getResponse()` without tracking the rendered widget. The working homepage uses explicit rendering and a widget ID.

## Validation

- JavaScript syntax checks passed for both roof-replacement scripts
- `git diff --check` passed
- both affected pages use the working production key `6LfD_bor...`
- both forms now use explicit render callbacks and widget-specific response/reset calls