### PR TITLE
Reset roof replacement reCAPTCHA after each attempt

### DIFF
--- a/roof-replacement-landing.js
+++ b/roof-replacement-landing.js
@@ -9,7 +9,13 @@
     const holder = document.getElementById("roof-replacement-recaptcha");
     if (!holder || !window.grecaptcha || recaptchaId !== null) return;
     recaptchaId = window.grecaptcha.render(holder, {
-      sitekey: holder.dataset.sitekey
+      sitekey: holder.dataset.sitekey,
+      "expired-callback": () => {
+        setMessage("reCAPTCHA expired. Please check the box again.", "error");
+      },
+      "error-callback": () => {
+        setMessage("reCAPTCHA could not load. Please refresh the page and try again.", "error");
+      }
     });
   };
 
@@ -109,9 +115,6 @@
       }
       form.reset();
       form.classList.remove("has-errors");
-      if (window.grecaptcha && recaptchaId !== null) {
-        window.grecaptcha.reset(recaptchaId);
-      }
       setMessage("Thank you. Your request was sent to Zenith Roofing Services.", "success");
     } catch (error) {
       console.error(error);
@@ -127,6 +130,11 @@
         "error"
       );
     } finally {
+      // A reCAPTCHA v2 token is single-use and can also expire. Reset after
+      // every attempt so a retry can never resend a stale token.
+      if (window.grecaptcha && recaptchaId !== null) {
+        window.grecaptcha.reset(recaptchaId);
+      }
       button.disabled = false;
       button.textContent = "Request My Free Estimate";
     }

--- a/roof-replacement/landing.js
+++ b/roof-replacement/landing.js
@@ -9,7 +9,13 @@
     const holder = document.getElementById("roof-replacement-recaptcha");
     if (!holder || !window.grecaptcha || recaptchaId !== null) return;
     recaptchaId = window.grecaptcha.render(holder, {
-      sitekey: holder.dataset.sitekey
+      sitekey: holder.dataset.sitekey,
+      "expired-callback": () => {
+        setMessage("reCAPTCHA expired. Please check the box again.", "error");
+      },
+      "error-callback": () => {
+        setMessage("reCAPTCHA could not load. Please refresh the page and try again.", "error");
+      }
     });
   };
 
@@ -102,9 +108,6 @@
         keyword: fd.get("utm_term") || ""
       });
       form.reset();
-      if (window.grecaptcha && recaptchaId !== null) {
-        window.grecaptcha.reset(recaptchaId);
-      }
       setMessage("Thank you. Your request was sent to Zenith Roofing Services.", "success");
     } catch (error) {
       console.error(error);
@@ -120,6 +123,11 @@
         "error"
       );
     } finally {
+      // A reCAPTCHA v2 token is single-use and can also expire. Reset after
+      // every attempt so a retry can never resend a stale token.
+      if (window.grecaptcha && recaptchaId !== null) {
+        window.grecaptcha.reset(recaptchaId);
+      }
       button.disabled = false;
       button.textContent = "Request My Free Estimate";
     }


### PR DESCRIPTION
## Root cause
The roof-replacement page reset its reCAPTCHA widget only after a successful submission. If an attempt failed—or the token expired—the next click reused the same single-use token, and Google returned `timeout-or-duplicate`.

## Fix
- Reset the roof-replacement reCAPTCHA after every submission attempt, successful or failed.
- Show a clear message when the checkbox token expires or reCAPTCHA cannot load.
- Apply the same correction to both copies of the roof-replacement form script.
- Leave the working homepage and financing forms unchanged.

## Verification
- JavaScript syntax checks passed for both files.
- `git diff --check` passed.