### PR TITLE
Fix validation retries across all lead forms

### DIFF
--- a/financing/index.html
+++ b/financing/index.html
@@ -256,7 +256,7 @@
             <div class="finance-form-grid">
               <div class="finance-form-field"><label for="fin-first-name">First name *</label><input id="fin-first-name" name="first_name" autocomplete="given-name" required></div>
               <div class="finance-form-field"><label for="fin-last-name">Last name *</label><input id="fin-last-name" name="last_name" autocomplete="family-name" required></div>
-              <div class="finance-form-field"><label for="fin-phone">Phone number *</label><input id="fin-phone" name="phone" type="tel" autocomplete="tel" inputmode="tel" placeholder="(760) 555-1234" pattern="\([0-9]{3}\) [0-9]{3}-[0-9]{4}" maxlength="14" required></div>
+              <div class="finance-form-field"><label for="fin-phone">Phone number *</label><input id="fin-phone" name="phone" type="tel" autocomplete="tel" inputmode="tel" placeholder="(760) 555-1234" pattern="\([0-9]{3}\) [0-9]{3}-[0-9]{4}" maxlength="18" required></div>
               <div class="finance-form-field"><label for="fin-email">Email address *</label><input id="fin-email" name="email" type="email" autocomplete="email" required></div>
               <div class="finance-form-field full"><label for="fin-street">Street address *</label><input id="fin-street" name="street_address" autocomplete="street-address" required></div>
               <div class="finance-form-field"><label for="fin-city">City *</label><input id="fin-city" name="city" autocomplete="address-level2" required></div>
@@ -426,10 +426,47 @@
       }
     });
     let financingRecaptchaId=null;
+    const financingPhone=document.getElementById('fin-phone');
+    const phoneDigits=function(value){
+      let digits=String(value||'').replace(/\D/g,'');
+      if(digits.length===11&&digits.startsWith('1'))digits=digits.slice(1);
+      return digits.slice(0,10);
+    };
+    const formatPhone=function(value){
+      const digits=phoneDigits(value);
+      if(digits.length<4)return digits;
+      if(digits.length<7)return '('+digits.slice(0,3)+') '+digits.slice(3);
+      return '('+digits.slice(0,3)+') '+digits.slice(3,6)+'-'+digits.slice(6);
+    };
+    const validatePhone=function(){
+      if(!financingPhone)return true;
+      financingPhone.value=formatPhone(financingPhone.value);
+      const digits=phoneDigits(financingPhone.value);
+      const valid=/^[2-9]\d{2}[2-9]\d{6}$/.test(digits);
+      financingPhone.setCustomValidity(valid?'':'Enter a valid 10-digit US phone number.');
+      return valid;
+    };
+    if(financingPhone){
+      financingPhone.addEventListener('input',function(){
+        financingPhone.value=formatPhone(financingPhone.value);
+        financingPhone.setCustomValidity('');
+      });
+      financingPhone.addEventListener('blur',validatePhone);
+    }
     window.onFinancingRecaptchaLoaded=function(){
       const holder=document.getElementById('financing-recaptcha');
       if(!holder||typeof grecaptcha==='undefined'||financingRecaptchaId!==null)return;
-      financingRecaptchaId=grecaptcha.render(holder,{sitekey:holder.dataset.sitekey});
+      financingRecaptchaId=grecaptcha.render(holder,{
+        sitekey:holder.dataset.sitekey,
+        'expired-callback':function(){
+          const status=document.getElementById('financing-form-status');
+          if(status){status.className='finance-form-status error';status.textContent='reCAPTCHA expired. Please check the box again.';}
+        },
+        'error-callback':function(){
+          const status=document.getElementById('financing-form-status');
+          if(status){status.className='finance-form-status error';status.textContent='reCAPTCHA could not load. Please refresh the page and try again.';}
+        }
+      });
     };
     document.addEventListener('submit',async function(e){
       const form=e.target.closest('#financing-lead-form');
@@ -439,6 +476,7 @@
       const status=document.getElementById('financing-form-status');
       status.className='finance-form-status';
       status.textContent='';
+      validatePhone();
       if(!form.checkValidity()){form.reportValidity();status.classList.add('error');status.textContent='Please complete the required fields highlighted in red.';return;}
       const captcha=typeof grecaptcha!=='undefined'&&financingRecaptchaId!==null
         ?grecaptcha.getResponse(financingRecaptchaId):'';
@@ -485,11 +523,14 @@
         window.dataLayer=window.dataLayer||[];
         window.dataLayer.push({event:'financing_estimate_lead',service_type:payload.service_type,lead_source:payload.referral_source});
         form.reset();form.classList.remove('was-validated');
-        if(typeof grecaptcha!=='undefined'&&financingRecaptchaId!==null)grecaptcha.reset(financingRecaptchaId);
       }catch(err){
         status.classList.add('error');
         status.textContent=err.message||'We could not send your request. Please call 858-900-6163.';
-      }finally{button.disabled=false;button.textContent=originalText;}
+      }finally{
+        // reCAPTCHA tokens are single-use. Always reset so a corrected form can be retried.
+        if(typeof grecaptcha!=='undefined'&&financingRecaptchaId!==null)grecaptcha.reset(financingRecaptchaId);
+        button.disabled=false;button.textContent=originalText;
+      }
     });
     document.addEventListener('click',function(e){
       const link=e.target.closest('.wisetack-link');

--- a/js/hero.js
+++ b/js/hero.js
@@ -47,7 +47,11 @@
   // ---------- Field validation ----------
   const emailOK = (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
   const zipOK   = (v) => /^\d{5}(-?\d{4})?$/.test(v);
-  const cleanDigits = (v) => (v || '').replace(/\D+/g, '');
+  const cleanDigits = (v) => {
+    let digits = (v || '').replace(/\D+/g, '');
+    if (digits.length === 11 && digits.startsWith('1')) digits = digits.slice(1);
+    return digits.slice(0, 10);
+  };
 
   function validateForm(form) {
     hideError(form);
@@ -75,11 +79,12 @@
       return false;
     }
 
-    const phoneRaw = $('#phone', form).value;
-    const phoneDigits = cleanDigits(phoneRaw);
-    if (phoneDigits.length < 10) {
-      showError(form, 'Please enter a valid phone number (10 digits).');
-      $('#phone', form).focus();
+    const phoneInput = $('#phone', form);
+    phoneInput.value = formatPhone(phoneInput.value);
+    const phoneDigits = cleanDigits(phoneInput.value);
+    if (!/^[2-9]\d{2}[2-9]\d{6}$/.test(phoneDigits)) {
+      showError(form, 'Please enter a valid 10-digit US phone number.');
+      phoneInput.focus();
       return false;
     }
 
@@ -94,16 +99,15 @@
   }
 
   // ---------- Phone masking ----------
+  function formatPhone(value) {
+    const digits = cleanDigits(value);
+    if (digits.length < 4) return digits;
+    if (digits.length < 7) return `(${digits.slice(0,3)}) ${digits.slice(3)}`;
+    return `(${digits.slice(0,3)}) ${digits.slice(3,6)}-${digits.slice(6)}`;
+  }
+
   function maskPhoneInput(e) {
-    const input = e.target;
-    const digits = input.value.replace(/\D+/g, '').slice(0, 10);
-    let out = digits;
-
-    if (digits.length > 6) out = `(${digits.slice(0,3)}) ${digits.slice(3,6)}-${digits.slice(6)}`;
-    else if (digits.length > 3) out = `(${digits.slice(0,3)}) ${digits.slice(3)}`;
-    else if (digits.length > 0) out = `(${digits}`;
-
-    input.value = out;
+    e.target.value = formatPhone(e.target.value);
   }
 
   // ---------- ZIP → City/State autofill ----------  // NEW
@@ -146,7 +150,11 @@
     if (!sitekey) return;
 
     try {
-      window._recaptchaWidgetId = window.grecaptcha.render(container, { sitekey });
+      window._recaptchaWidgetId = window.grecaptcha.render(container, {
+        sitekey,
+        'expired-callback': () => showError(document.getElementById('estimate-form'), 'reCAPTCHA expired. Please check the box again.'),
+        'error-callback': () => showError(document.getElementById('estimate-form'), 'reCAPTCHA could not load. Please refresh the page and try again.')
+      });
     } catch (e) {
       // noop
     }
@@ -243,19 +251,21 @@
       form.reset();
       hideError(form);
 
-      if (window.grecaptcha &&
-          typeof window.grecaptcha.reset === 'function' &&
-          typeof window._recaptchaWidgetId !== 'undefined') {
-        window.grecaptcha.reset(window._recaptchaWidgetId);
-      } else {
-        const t = document.querySelector('textarea[name="g-recaptcha-response"]');
-        if (t) t.value = '';
-      }
 
     } catch (err) {
       console.error(err);
       showError(form, 'Network error. Please try again.');
     } finally {
+      // reCAPTCHA tokens are single-use. Always reset so corrections can be retried.
+      if (window.grecaptcha && typeof window.grecaptcha.reset === 'function') {
+        if (typeof window._recaptchaWidgetId !== 'undefined') {
+          window.grecaptcha.reset(window._recaptchaWidgetId);
+        } else {
+          window.grecaptcha.reset();
+        }
+      }
+      const captchaField = document.querySelector('textarea[name="g-recaptcha-response"]');
+      if (captchaField) captchaField.value = '';
       if (submitBtn && originalText) {
         submitBtn.textContent = originalText;
         submitBtn.disabled = false;

--- a/netlify/functions/jn-create-lead.js
+++ b/netlify/functions/jn-create-lead.js
@@ -45,7 +45,11 @@ const parseBody = (event) => {
 
 // ===== Helpers =====
 const onlyDigits = (s) => (s || '').replace(/\D+/g, '');
-const normalizePhone = (s) => onlyDigits(s).slice(0, 10);
+const normalizePhone = (s) => {
+  let digits = onlyDigits(s);
+  if (digits.length === 11 && digits.startsWith('1')) digits = digits.slice(1);
+  return digits.slice(0, 10);
+};
 
 exports.handler = async (event) => {
   const origin = event.headers?.origin || event.headers?.Origin || '';
@@ -74,35 +78,6 @@ exports.handler = async (event) => {
       .trim()
       .replace(/^bearer\s+/i, '');
     const contactEndpoint = JN_CONTACT_ENDPOINT.trim();
-
-    // ---- reCAPTCHA (if enabled) ----
-    if (RECAPTCHA_SECRET) {
-      const token = (data.recaptcha_token || '').trim();
-      if (!token) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: 'Missing recaptcha token' }) };
-      const verifyRes = await fetch('https://www.google.com/recaptcha/api/siteverify', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ secret: RECAPTCHA_SECRET, response: token }),
-      });
-      const verifyJson = await verifyRes.json();
-      console.log('[jn-create-lead] recaptcha verification:', {
-        success: verifyJson.success,
-        hostname: verifyJson.hostname || '',
-        errorCodes: verifyJson['error-codes'] || []
-      });
-      if (!verifyJson.success) {
-        const errorCodes = Array.isArray(verifyJson['error-codes'])
-          ? verifyJson['error-codes'].join(', ')
-          : '';
-        return {
-          statusCode: 400,
-          headers: cors,
-          body: JSON.stringify({
-            error: errorCodes ? `Recaptcha failed: ${errorCodes}` : 'Recaptcha failed'
-          })
-        };
-      }
-    }
 
     // ---- Normalize inputs (needed later) ----
     const first = (data.first_name || '').trim();
@@ -161,6 +136,36 @@ exports.handler = async (event) => {
     if (!/^[2-9]\d{2}[2-9]\d{6}$/.test(phoneDigits))
       return { statusCode: 400, headers: cors, body: JSON.stringify({ error: 'Enter a valid 10-digit US phone number' }) };
     const formattedPhone = `(${phoneDigits.slice(0,3)}) ${phoneDigits.slice(3,6)}-${phoneDigits.slice(6)}`;
+
+    // ---- reCAPTCHA (if enabled) ----
+    if (RECAPTCHA_SECRET) {
+      const token = (data.recaptcha_token || '').trim();
+      if (!token) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: 'Missing recaptcha token' }) };
+      const verifyRes = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ secret: RECAPTCHA_SECRET, response: token }),
+      });
+      const verifyJson = await verifyRes.json();
+      console.log('[jn-create-lead] recaptcha verification:', {
+        success: verifyJson.success,
+        hostname: verifyJson.hostname || '',
+        errorCodes: verifyJson['error-codes'] || []
+      });
+      if (!verifyJson.success) {
+        const errorCodes = Array.isArray(verifyJson['error-codes'])
+          ? verifyJson['error-codes'].join(', ')
+          : '';
+        return {
+          statusCode: 400,
+          headers: cors,
+          body: JSON.stringify({
+            error: errorCodes ? `Recaptcha failed: ${errorCodes}` : 'Recaptcha failed'
+          })
+        };
+      }
+    }
+
 
     // ---- Description BACKUP (include EVERYTHING useful) ----
     const addressLine = [addressObj.street, addressObj.city, addressObj.state, addressObj.zip]

--- a/roof-replacement-landing.js
+++ b/roof-replacement-landing.js
@@ -9,12 +9,48 @@
     const holder = document.getElementById("roof-replacement-recaptcha");
     if (!holder || !window.grecaptcha || recaptchaId !== null) return;
     recaptchaId = window.grecaptcha.render(holder, {
-      sitekey: holder.dataset.sitekey
+      sitekey: holder.dataset.sitekey,
+      "expired-callback": () => {
+        setMessage("reCAPTCHA expired. Please check the box again.", "error");
+      },
+      "error-callback": () => {
+        setMessage("reCAPTCHA could not load. Please refresh the page and try again.", "error");
+      }
     });
   };
 
   const message = form.querySelector(".form-message");
   const button = form.querySelector('button[type="submit"]');
+  const phoneInput = form.querySelector('input[name="phone"]');
+
+  const phoneDigits = (value) => {
+    let digits = String(value || "").replace(/\D/g, "");
+    if (digits.length === 11 && digits.startsWith("1")) digits = digits.slice(1);
+    return digits.slice(0, 10);
+  };
+
+  const formatPhone = (value) => {
+    const digits = phoneDigits(value);
+    if (digits.length < 4) return digits;
+    if (digits.length < 7) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+  };
+
+  const validatePhone = () => {
+    if (!phoneInput) return true;
+    phoneInput.value = formatPhone(phoneInput.value);
+    const valid = /^[2-9]\d{2}[2-9]\d{6}$/.test(phoneDigits(phoneInput.value));
+    phoneInput.setCustomValidity(valid ? "" : "Enter a valid 10-digit US phone number.");
+    return valid;
+  };
+
+  if (phoneInput) {
+    phoneInput.addEventListener("input", () => {
+      phoneInput.value = formatPhone(phoneInput.value);
+      phoneInput.setCustomValidity("");
+    });
+    phoneInput.addEventListener("blur", validatePhone);
+  }
   const params = new URLSearchParams(location.search);
   const campaignKeys = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "gclid"];
 
@@ -47,6 +83,7 @@
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
     form.classList.add("has-errors");
+    validatePhone();
     if (!form.reportValidity()) return;
 
     let token = "";
@@ -109,9 +146,6 @@
       }
       form.reset();
       form.classList.remove("has-errors");
-      if (window.grecaptcha && recaptchaId !== null) {
-        window.grecaptcha.reset(recaptchaId);
-      }
       setMessage("Thank you. Your request was sent to Zenith Roofing Services.", "success");
     } catch (error) {
       console.error(error);
@@ -127,6 +161,10 @@
         "error"
       );
     } finally {
+      // reCAPTCHA tokens are single-use. Always reset so a corrected form can be retried.
+      if (window.grecaptcha && recaptchaId !== null) {
+        window.grecaptcha.reset(recaptchaId);
+      }
       button.disabled = false;
       button.textContent = "Request My Free Estimate";
     }

--- a/roof-replacement/landing.js
+++ b/roof-replacement/landing.js
@@ -9,12 +9,48 @@
     const holder = document.getElementById("roof-replacement-recaptcha");
     if (!holder || !window.grecaptcha || recaptchaId !== null) return;
     recaptchaId = window.grecaptcha.render(holder, {
-      sitekey: holder.dataset.sitekey
+      sitekey: holder.dataset.sitekey,
+      "expired-callback": () => {
+        setMessage("reCAPTCHA expired. Please check the box again.", "error");
+      },
+      "error-callback": () => {
+        setMessage("reCAPTCHA could not load. Please refresh the page and try again.", "error");
+      }
     });
   };
 
   const message = form.querySelector(".form-message");
   const button = form.querySelector('button[type="submit"]');
+  const phoneInput = form.querySelector('input[name="phone"]');
+
+  const phoneDigits = (value) => {
+    let digits = String(value || "").replace(/\D/g, "");
+    if (digits.length === 11 && digits.startsWith("1")) digits = digits.slice(1);
+    return digits.slice(0, 10);
+  };
+
+  const formatPhone = (value) => {
+    const digits = phoneDigits(value);
+    if (digits.length < 4) return digits;
+    if (digits.length < 7) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+  };
+
+  const validatePhone = () => {
+    if (!phoneInput) return true;
+    phoneInput.value = formatPhone(phoneInput.value);
+    const valid = /^[2-9]\d{2}[2-9]\d{6}$/.test(phoneDigits(phoneInput.value));
+    phoneInput.setCustomValidity(valid ? "" : "Enter a valid 10-digit US phone number.");
+    return valid;
+  };
+
+  if (phoneInput) {
+    phoneInput.addEventListener("input", () => {
+      phoneInput.value = formatPhone(phoneInput.value);
+      phoneInput.setCustomValidity("");
+    });
+    phoneInput.addEventListener("blur", validatePhone);
+  }
   const params = new URLSearchParams(location.search);
   const campaignKeys = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content", "gclid"];
 
@@ -46,6 +82,7 @@
 
   form.addEventListener("submit", async (e) => {
     e.preventDefault();
+    validatePhone();
     if (!form.reportValidity()) return;
 
     let token = "";
@@ -102,9 +139,6 @@
         keyword: fd.get("utm_term") || ""
       });
       form.reset();
-      if (window.grecaptcha && recaptchaId !== null) {
-        window.grecaptcha.reset(recaptchaId);
-      }
       setMessage("Thank you. Your request was sent to Zenith Roofing Services.", "success");
     } catch (error) {
       console.error(error);
@@ -120,6 +154,10 @@
         "error"
       );
     } finally {
+      // reCAPTCHA tokens are single-use. Always reset so a corrected form can be retried.
+      if (window.grecaptcha && recaptchaId !== null) {
+        window.grecaptcha.reset(recaptchaId);
+      }
       button.disabled = false;
       button.textContent = "Request My Free Estimate";
     }


### PR DESCRIPTION
## Problems fixed
- Homepage and financing reCAPTCHA tokens could be consumed by a failed server validation and then reused, producing `timeout-or-duplicate` until the page was refreshed.
- Financing and landing-page widgets reset only after success, not after failed submission attempts.
- Autofilled U.S. phone numbers beginning with country code `1` were rejected.
- The roof-replacement phone field did not format the number while typing.

## Changes
- Validate all submitted fields on the server before verifying/consuming the reCAPTCHA token.
- Reset reCAPTCHA after every actual submission attempt on homepage, financing, and roof-replacement forms.
- Add expiration/error messages to each explicitly rendered widget.
- Normalize an 11-digit U.S. number beginning with `1` to its standard 10 digits.
- Format phone inputs as `(###) ###-####` on financing and roof-replacement forms; improve the homepage formatter to accept country-code autofill.
- Apply the roof-replacement fix to both copies of its script.

## Verification
- All changed JavaScript, including the financing inline scripts, parses successfully.
- Changes are limited to the shared lead handler and the three lead-form implementations.

This PR supersedes #66.