### PR TITLE
Track Wisetack clicks as Google Ads conversions

### DIFF
--- a/financing/index.html
+++ b/financing/index.html
@@ -537,7 +537,10 @@
       if(!link)return;
       window.dataLayer=window.dataLayer||[];
       window.dataLayer.push({event:'wisetack_prequalification_click',page_path:location.pathname,link_url:link.href});
-      if(typeof gtag==='function')gtag('event','wisetack_prequalification_click',{event_category:'Financing',event_label:location.pathname,transport_type:'beacon'});
+      if(typeof gtag==='function'){
+        gtag('event','wisetack_prequalification_click',{event_category:'Financing',event_label:location.pathname,transport_type:'beacon'});
+        gtag('event','conversion',{send_to:'AW-574510700/VZ4dCIL0n9kcEOys-ZEC',transport_type:'beacon'});
+      }
     });
   </script>
   <script src="https://www.google.com/recaptcha/api.js?onload=onFinancingRecaptchaLoaded&render=explicit" async defer></script>

--- a/roof-replacement-landing.js
+++ b/roof-replacement-landing.js
@@ -72,7 +72,15 @@
   });
 
   document.querySelectorAll(".track-financing").forEach((link) => {
-    link.addEventListener("click", () => event("wisetack_prequal_click", { page_path: location.pathname }));
+    link.addEventListener("click", () => {
+      event("wisetack_prequal_click", { page_path: location.pathname });
+      if (typeof window.gtag === "function") {
+        window.gtag("event", "conversion", {
+          send_to: "AW-574510700/VZ4dCIL0n9kcEOys-ZEC",
+          transport_type: "beacon"
+        });
+      }
+    });
   });
 
   const setMessage = (text, type) => {

--- a/roof-replacement/landing.js
+++ b/roof-replacement/landing.js
@@ -72,7 +72,15 @@
   });
 
   document.querySelectorAll(".track-financing").forEach((link) => {
-    link.addEventListener("click", () => event("wisetack_prequal_click", { page_path: location.pathname }));
+    link.addEventListener("click", () => {
+      event("wisetack_prequal_click", { page_path: location.pathname });
+      if (typeof window.gtag === "function") {
+        window.gtag("event", "conversion", {
+          send_to: "AW-574510700/VZ4dCIL0n9kcEOys-ZEC",
+          transport_type: "beacon"
+        });
+      }
+    });
   });
 
   const setMessage = (text, type) => {


### PR DESCRIPTION
## What changed
- Fires the new Google Ads conversion `AW-574510700/VZ4dCIL0n9kcEOys-ZEC` when a visitor clicks a Wisetack prequalification link.
- Covers all five Wisetack links on `/financing/` and the direct Wisetack link on both roof-replacement page variants.
- Preserves the existing custom analytics events.
- Uses beacon delivery without the generated redirect callback because every Wisetack link already opens safely in a new tab.

## Verification
- Parsed every changed JavaScript block successfully.
- No form-submission, reCAPTCHA, JobNimbus, or destination-link behavior changed.