### PR TITLE
Rebuild services directory for SEO and local discovery

### DIFF
--- a/css/services-directory.css
+++ b/css/services-directory.css
@@ -1,0 +1,315 @@
+.services-directory-hero {
+  padding: clamp(56px, 7vw, 92px) 24px;
+  color: #fff;
+  background:
+    linear-gradient(90deg, rgba(3, 34, 67, .97), rgba(7, 46, 89, .88)),
+    url("/images/zenith-van-optimized.jpg") center / cover no-repeat;
+}
+
+.services-hero-grid {
+  display: grid;
+  gap: clamp(30px, 6vw, 72px);
+  align-items: center;
+}
+
+.services-eyebrow,
+.services-section-label {
+  margin: 0 0 10px;
+  color: #f7941d;
+  font-size: .78rem;
+  font-weight: 850;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.services-directory-hero h1 {
+  max-width: 800px;
+  margin: 0;
+  color: #fff;
+  font-size: clamp(2.4rem, 5vw, 4.7rem);
+  line-height: 1.03;
+  letter-spacing: -.045em;
+}
+
+.services-hero-lede {
+  max-width: 740px;
+  margin: 22px 0 0;
+  color: rgba(255,255,255,.92);
+  font-size: clamp(1.05rem, 1.5vw, 1.2rem);
+  line-height: 1.7;
+}
+
+.services-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.services-primary-button,
+.services-secondary-button {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 20px;
+  border: 2px solid #f7941d;
+  border-radius: 10px;
+  font-weight: 800;
+}
+
+.services-primary-button {
+  color: #072e59;
+  background: #f7941d;
+}
+
+.services-secondary-button {
+  color: #fff;
+  border-color: rgba(255,255,255,.75);
+  background: rgba(7,46,89,.28);
+}
+
+.services-trust-list {
+  display: grid;
+  gap: 10px 24px;
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.services-trust-list li {
+  position: relative;
+  padding-left: 22px;
+  font-weight: 650;
+}
+
+.services-trust-list li::before {
+  position: absolute;
+  left: 0;
+  color: #f7941d;
+  content: "✓";
+  font-weight: 900;
+}
+
+.services-hero-card {
+  padding: clamp(24px, 4vw, 38px);
+  color: #172033;
+  border: 1px solid rgba(255,255,255,.55);
+  border-radius: 18px;
+  background: rgba(255,255,255,.97);
+  box-shadow: 0 22px 60px rgba(0,0,0,.24);
+}
+
+.services-hero-card h2 {
+  margin: 0 0 14px;
+  color: #072e59;
+  font-size: clamp(1.45rem, 2.2vw, 2rem);
+}
+
+.services-hero-card p {
+  color: #536174;
+  line-height: 1.65;
+}
+
+.services-hero-card a,
+.services-category-heading > a,
+.services-card > a {
+  color: #075fa9;
+  font-weight: 800;
+  text-decoration: underline;
+  text-decoration-color: rgba(247,148,29,.65);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+}
+
+.services-intro,
+.services-category,
+.services-faq,
+.services-estimate {
+  padding: clamp(54px, 7vw, 88px) 24px;
+  scroll-margin-top: 175px;
+}
+
+.services-intro {
+  padding-bottom: 18px;
+  text-align: center;
+}
+
+.services-intro h2,
+.services-category-heading h2,
+.services-faq h2,
+.services-estimate h2 {
+  margin: 0;
+  color: #072e59;
+  font-size: clamp(1.8rem, 3.3vw, 3rem);
+  line-height: 1.12;
+  letter-spacing: -.025em;
+}
+
+.services-intro p:last-child {
+  max-width: 820px;
+  margin: 18px auto 0;
+  color: #5e6b7d;
+  font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.services-category-alt,
+.services-faq {
+  background: #f3f6f9;
+}
+
+.services-category-heading {
+  display: flex;
+  gap: 20px;
+  align-items: end;
+  justify-content: space-between;
+  margin-bottom: 28px;
+}
+
+.services-category-heading > a {
+  flex: 0 0 auto;
+  padding-bottom: 4px;
+}
+
+.services-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 265px), 1fr));
+  gap: 18px;
+}
+
+.services-card {
+  display: flex;
+  min-height: 235px;
+  flex-direction: column;
+  padding: 25px;
+  border: 1px solid #dce3eb;
+  border-radius: 15px;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(7,46,89,.07);
+  transition: transform .2s ease, border-color .2s ease, box-shadow .2s ease;
+}
+
+.services-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(247,148,29,.55);
+  box-shadow: 0 16px 38px rgba(7,46,89,.12);
+}
+
+.services-card h3 {
+  margin: 0;
+  color: #072e59;
+  font-size: 1.22rem;
+  line-height: 1.3;
+}
+
+.services-card p {
+  margin: 13px 0 20px;
+  color: #5e6b7d;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.services-card > a {
+  width: fit-content;
+  margin-top: auto;
+}
+
+.services-faq-list {
+  display: grid;
+  max-width: 920px;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.services-faq details {
+  padding: 0 20px;
+  border: 1px solid #dce3eb;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.services-faq summary {
+  padding: 19px 34px 19px 0;
+  color: #072e59;
+  cursor: pointer;
+  font-size: 1.05rem;
+  font-weight: 800;
+}
+
+.services-faq details p {
+  margin: 0 0 20px;
+  color: #5e6b7d;
+  line-height: 1.7;
+}
+
+.services-estimate-heading {
+  max-width: 760px;
+  margin-bottom: 26px;
+}
+
+.services-estimate-heading > p:last-child,
+.services-estimate-note {
+  color: #5e6b7d;
+  line-height: 1.7;
+}
+
+.services-estimate-note {
+  margin-top: 12px;
+  font-size: .9rem;
+}
+
+.catalog-subnav .inner {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.catalog-subnav .inner::-webkit-scrollbar {
+  display: none;
+}
+
+.catalog-subnav a {
+  flex: 0 0 auto;
+}
+
+@media (min-width: 840px) {
+  .services-hero-grid {
+    grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr);
+  }
+
+  .services-trust-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .services-directory-hero,
+  .services-intro,
+  .services-category,
+  .services-faq,
+  .services-estimate {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .services-category-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .services-card {
+    min-height: 0;
+  }
+
+  .services-primary-button,
+  .services-secondary-button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .services-card {
+    transition: none;
+  }
+}

--- a/services/index.html
+++ b/services/index.html
@@ -2,350 +2,271 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Roofing Services in San Diego & Temecula | Commercial, Residential & Real Estate</title>
+  <title>Roofing Services in San Diego County | Zenith Roofing Services</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="description" content="Explore all roofing services from Zenith Roofing Services: commercial roof replacement (TPO/PVC, modified bitumen, coatings, SPF, metal), residential reroofs (shingle, tile lift & lay), repairs, inspections, and transaction-ready real estate services. Mobile-friendly. Fast quotes." />
-  <link rel="canonical" href="/services/" />
+  <meta name="description" content="Explore roof replacement, repairs, tile, shingle, TPO, torch-down, silicone coating, inspections, gutters, storm claims, commercial roofing and real estate roof services in San Diego County." />
+  <link rel="canonical" href="https://zenithroofingservices.com/services/" />
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large" />
 
-  <!-- Global CSS -->
   <link rel="preload" href="/css/base.css" as="style" />
   <link rel="preload" href="/css/header.css" as="style" />
-  <link rel="preload" href="/css/ui.css" as="style" />
   <link rel="stylesheet" href="/css/base.css" />
   <link rel="stylesheet" href="/css/header.css" />
   <link rel="stylesheet" href="/css/ui.css" />
   <link rel="stylesheet" href="/css/footer.css" />
   <link rel="stylesheet" href="/css/estimate-form.css" />
-  <link rel="stylesheet" href="/css/landing-theme-preview.css?v=sitewide-2">
+  <link rel="stylesheet" href="/css/landing-theme-preview.css?v=sitewide-2" />
+  <link rel="stylesheet" href="/css/services-directory.css?v=1" />
 </head>
 <body>
-  <!-- Header -->
   <div data-include="/components/header-section.html"></div>
 
-  <!-- Sticky section nav -->
-  <nav class="catalog-subnav" aria-label="Services sections">
+  <nav class="catalog-subnav" aria-label="Service categories">
     <div class="container inner">
-      <a href="#featured">Featured</a>
-      <a href="#commercial">Commercial</a>
+      <a href="#replacement">Replacement</a>
+      <a href="#repairs">Repairs</a>
       <a href="#residential">Residential</a>
+      <a href="#commercial">Commercial</a>
+      <a href="#claims">Storm Claims</a>
       <a href="#real-estate">Real Estate</a>
-      <a href="#repairs">Repairs & Inspections</a>
       <a href="#estimate">Estimate</a>
     </div>
   </nav>
 
   <main>
-    <!-- Hero -->
-    <section class="catalog-hero">
-      <div class="container stack">
+    <section class="services-directory-hero">
+      <div class="container services-hero-grid">
         <div>
-          <div class="catalog-eyebrow">Zenith Roofing Services • C-39 Licensed & Insured</div>
-          <h1 class="hero-title">All Roofing Services</h1>
-          <p class="hero-subtitle">
-            One place for <strong>commercial</strong>, <strong>residential</strong>, <strong>repairs & inspections</strong>, and <strong>real estate</strong> services. 
-            Mobile-friendly, fast to navigate, with clear links to each service page.
-          </p>
-          <div style="margin-top:12px">
-            <a href="tel:8589006163" class="btn-solid">Call 858-900-6163</a>
-            <a href="#estimate" class="btn-outline">Request an Estimate</a>
+          <p class="services-eyebrow">Licensed California roofing contractor · CSLB C-39 #1036112</p>
+          <h1>Roofing Services for San Diego County Homes and Businesses</h1>
+          <p class="services-hero-lede">Zenith Roofing Services handles roof replacement, repairs, maintenance, inspections, storm claims and commercial roofing systems. Browse the service you need, learn what it includes and request a clear next step from a local roofing contractor.</p>
+          <div class="services-hero-actions">
+            <a class="services-primary-button" href="#estimate">Request an Estimate</a>
+            <a class="services-secondary-button" href="tel:8589006163">Call 858-900-6163</a>
           </div>
+          <ul class="services-trust-list" aria-label="Why homeowners choose Zenith">
+            <li>Licensed and insured</li>
+            <li>Google Guaranteed</li>
+            <li>Photo-documented recommendations</li>
+            <li>Residential and commercial expertise</li>
+          </ul>
         </div>
-        <!-- Optional brand image card (falls back if missing) -->
-        <aside aria-label="Zenith field photo">
-          <div class="photo-card">
-            <img src="/images/zenith-van.jpg" alt="Zenith Roofing Services service vehicle" loading="lazy" decoding="async" />
-          </div>
+        <aside class="services-hero-card" aria-label="Roofing systems and service area">
+          <h2>Roofing built for Southern California</h2>
+          <p>We work with tile, asphalt shingles, TPO, torch-down modified bitumen, silicone restoration systems and commercial metal roofing.</p>
+          <p><strong>Primary service area:</strong> San Diego County and Southwest Riverside County.</p>
+          <a href="/contact/">Talk With a Roofer</a>
         </aside>
       </div>
     </section>
 
-    <!-- Featured -->
-    <section id="featured" class="light-section">
+    <section class="services-intro">
       <div class="container">
-        <div class="section-kicker">Start here</div>
-        <h2 class="section-title">Featured services</h2>
-        <p class="section-lede">Most requested pages—quick links that answer 80% of what owners and agents need.</p>
-        <div class="catalog-grid">
-          <article class="service-card">
-            <h3>Commercial & Residential Roof Replacement</h3>
-            <p class="service-meta">TPO/PVC • Modified Bitumen • Coatings • SPF • Metal • Shingle • Tile</p>
-            <p>Low-disruption reroofs for warehouses, restaurants, retail/HOA, and homes. Title 24 assemblies, clean sites, and warranty options.</p>
-            <div class="service-actions">
-              <a class="btn-solid" href="/services/roof-replacement/">View Roof Replacement</a>
-            </div>
-          </article>
+        <p class="services-section-label">Complete service directory</p>
+        <h2>Choose the roofing service that fits your property</h2>
+        <p>Each page below explains the system, typical applications and what to expect. If you are unsure where to start, choose <a href="/services/roof-inspection/">Roof Inspection</a> or contact our team.</p>
+      </div>
+    </section>
 
-          <article class="service-card">
-            <h3>Roof Repairs</h3>
-            <p class="service-meta">Leaks • Flashings • Skylights • Storm Response</p>
-            <p>Targeted repairs with photos and clear scope. We address root cause, not just symptoms.</p>
-            <div class="service-actions">
-              <a class="btn-solid" href="/services/roof-repairs/">View Roof Repairs</a>
-            </div>
-          </article>
-
-          <article class="service-card">
-            <h3>Real Estate Services</h3>
-            <p class="service-meta">Certified Reports • Estimates • Inspections • Certifications</p>
-            <p>Transaction-ready deliverables for agents, buyers, sellers & lenders with rush options available.</p>
-            <div class="service-actions">
-              <a class="btn-solid" href="/services/real-estate/">Explore Real Estate Services</a>
-            </div>
-          </article>
+    <section id="replacement" class="services-category">
+      <div class="container">
+        <div class="services-category-heading">
+          <div>
+            <p class="services-section-label">Roof replacement</p>
+            <h2>Replacement options for pitched and low-slope roofs</h2>
+          </div>
+          <a href="/services/roof-replacement/">View All Replacement Options</a>
+        </div>
+        <div class="services-card-grid">
+          <article class="services-card"><h3>Roof Replacement</h3><p>Plan a complete reroof with clear material options, documented scope and a system suited to your building.</p><a href="/services/roof-replacement/">Learn More</a></article>
+          <article class="services-card"><h3>Pitched Roof Replacement</h3><p>Replacement planning for sloped tile and shingle roofs, including underlayment, flashings and ventilation.</p><a href="/services/roof-replacement/pitched-roof/">Learn More</a></article>
+          <article class="services-card"><h3>Flat and Low-Slope Roof Replacement</h3><p>Complete replacement options for TPO, torch-down and other low-slope roof assemblies.</p><a href="/services/roof-replacement/flat-roof/">Learn More</a></article>
+          <article class="services-card"><h3>Not Sure Which Roof System?</h3><p>Compare replacement paths based on roof slope, existing materials, drainage, budget and property use.</p><a href="/services/roof-replacement/not-sure/">Learn More</a></article>
         </div>
       </div>
     </section>
 
-    <!-- Commercial -->
-    <section id="commercial" class="container">
-      <div class="section-kicker">Commercial roofing</div>
-      <h2 class="section-title">Systems & replacements for businesses</h2>
-      <div class="catalog-grid">
-        <article class="service-card">
-          <h3>TPO / PVC (WeatherBond)</h3>
-          <p>Cool-roof membranes with welded seams; PVC preferred near kitchen exhausts.</p>
-          <div class="service-actions">
-            <a class="btn-outline" href="/services/commercial/tpo/">TPO/PVC Details</a>
-            <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Modified Bitumen (Torch-Down)</h3>
-          <p>Durable multi-ply assemblies for heavy traffic and equipment zones.</p>
-          <div class="service-actions">
-            <a class="btn-outline" href="/services/commercial/torch-down/">Modified Bitumen</a>
-            <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Silicone Restoration (Coatings)</h3>
-          <p>Extend life on eligible roofs with reinforced seams and high-solids silicone topcoat.</p>
-          <div class="service-actions">
-            <a class="btn-outline" href="/services/commercial/silicone-coatings/">Coating Systems</a>
-            <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>SPF Foam + Coating</h3>
-          <p>Monolithic, insulated system that seals difficult details and boosts R-value.</p>
-          <div class="service-actions">
-            <a class="btn-outline" href="/services/commercial/tpo/">SPF Overview</a>
-            <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Metal Retrofits</h3>
-          <p>Retrofit or overlay assemblies; integrates with skylights and RTU curbs.</p>
-          <div class="service-actions">
-            <a class="btn-outline" href="/services/commercial/metal/">Metal Options</a>
-            <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-          </div>
-        </article>
-      </div>
-    </section>
-
-    <!-- Residential -->
-    <section id="residential" class="light-section">
+    <section id="repairs" class="services-category services-category-alt">
       <div class="container">
-        <div class="section-kicker">Residential roofing</div>
-        <h2 class="section-title">Reroofs & upgrades for homes</h2>
-        <div class="catalog-grid">
-          <article class="service-card">
-            <h3>Architectural Shingles</h3>
-            <p>Owens Corning Duration Cool options for Title 24 compliance.</p>
-            <div class="service-actions">
-              <a class="btn-outline" href="/services/roof-repairs/">Shingle Info</a>
-              <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-            </div>
-          </article>
-
-          <article class="service-card">
-            <h3>Tile Lift &amp; Lay</h3>
-            <p>Replace underlayment, update metals, and reinstall existing tiles.</p>
-            <div class="service-actions">
-              <a class="btn-outline" href="/services/roof-repairs/">Tile Details</a>
-              <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-            </div>
-          </article>
-
-          <article class="service-card">
-            <h3>Low-Slope Home Areas</h3>
-            <p>Self-adhered mod-bit or TPO transitions with proper tie-ins.</p>
-            <div class="service-actions">
-              <a class="btn-outline" href="/services/roof-repairs/">Low-Slope Options</a>
-              <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-            </div>
-          </article>
-
-          <article class="service-card">
-            <h3>Skylights & Flashings</h3>
-            <p>Energy-efficient skylight upgrades and leak-resistant curb details.</p>
-            <div class="service-actions">
-              <a class="btn-outline" href="/services/roof-repairs/">Details & Upgrades</a>
-              <a class="btn-solid" href="/services/roof-replacement/">Replacement Options</a>
-            </div>
-          </article>
+        <div class="services-category-heading">
+          <div>
+            <p class="services-section-label">Repairs, inspection and maintenance</p>
+            <h2>Find the cause, protect the property and extend roof life</h2>
+          </div>
+          <a href="/services/roof-repairs/">View All Roof Repairs</a>
+        </div>
+        <div class="services-card-grid">
+          <article class="services-card"><h3>Roof Repairs</h3><p>Targeted residential and commercial repairs supported by inspection findings and photo documentation.</p><a href="/services/roof-repairs/">Learn More</a></article>
+          <article class="services-card"><h3>Roof Inspection</h3><p>A professional roof assessment to identify visible damage, maintenance needs and practical next steps.</p><a href="/services/roof-inspection/">Learn More</a></article>
+          <article class="services-card"><h3>Leak Repair and Troubleshooting</h3><p>Trace active or intermittent leaks to likely entry points instead of treating only the interior symptom.</p><a href="/services/residential/leak-repair-troubleshooting/">Learn More</a></article>
+          <article class="services-card"><h3>Tile Roof Repair</h3><p>Repair cracked, slipped or displaced roof tiles and address vulnerable flashing and underlayment areas.</p><a href="/services/roof-repairs/tile-roof-repair/">Learn More</a></article>
+          <article class="services-card"><h3>Clay Tile Roof Repair</h3><p>Careful repairs for clay tile roofs with attention to fragile field tile, flashings and water pathways.</p><a href="/services/roof-repairs/clay-tile-roof-repair/">Learn More</a></article>
+          <article class="services-card"><h3>Broken Tile Replacement</h3><p>Replace isolated broken tiles and check the surrounding area for movement or exposed underlayment.</p><a href="/services/roof-repairs/broken-tile-replacement/">Learn More</a></article>
+          <article class="services-card"><h3>Shingle Roof Repair</h3><p>Repair damaged or missing shingles, exposed fasteners, flashings and other common leak locations.</p><a href="/services/roof-repairs/shingles-roof-repair/">Learn More</a></article>
+          <article class="services-card"><h3>Flat Roof Repair</h3><p>Repair punctures, open seams, failing transitions and drainage-related trouble on low-slope roofs.</p><a href="/services/roof-repairs/flat-roof-repair/">Learn More</a></article>
+          <article class="services-card"><h3>Skylight Repair</h3><p>Inspect and repair skylight curbs, flashings, seals and nearby roofing components.</p><a href="/services/roof-repairs/skylight-repair/">Learn More</a></article>
+          <article class="services-card"><h3>Slate Roof Repair</h3><p>Evaluate damaged slate and complete focused repairs that respect the existing roof assembly.</p><a href="/services/roof-repairs/slate-roof-repair/">Learn More</a></article>
+          <article class="services-card"><h3>Roof Tune-Up</h3><p>Address minor defects, exposed details and maintenance items before they become larger repairs.</p><a href="/services/roof-repairs/roof-tune-up/">Learn More</a></article>
+          <article class="services-card"><h3>Roof Cleaning and Maintenance</h3><p>Remove roof debris and maintain drainage paths, valleys and vulnerable details.</p><a href="/services/roof-repairs/roof-cleaning-maintenance/">Learn More</a></article>
+          <article class="services-card"><h3>Preventive Roof Maintenance</h3><p>Scheduled checks and upkeep for homeowners who want to reduce avoidable roof problems.</p><a href="/services/residential/preventive-maintenance/">Learn More</a></article>
+          <article class="services-card"><h3>Roof Washing and Moss Removal</h3><p>Roof-appropriate cleaning and organic growth removal based on the condition and material.</p><a href="/services/residential/roof-washing-moss-removal/">Learn More</a></article>
+          <article class="services-card"><h3>Rain Gutters</h3><p>Gutter services that help move roof runoff away from fascia, walls, walkways and foundations.</p><a href="/services/gutters/">Learn More</a></article>
         </div>
       </div>
     </section>
 
-    <!-- Real Estate -->
-    <section id="real-estate" class="container">
-      <div class="section-kicker">Real estate services</div>
-      <h2 class="section-title">Transaction-ready deliverables</h2>
-      <div class="catalog-grid">
-        <article class="service-card">
-          <h3>Certified Roof Reports</h3>
-          <p>Condition summary, lifespan opinion, photo set, and repair scope if needed.</p>
-          <div class="service-actions">
-            <a class="btn-solid" href="/services/real-estate/roof-reports/">View Service</a>
-            <a class="btn-outline" href="/services/real-estate/">All Real Estate</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Pre-Sale Roofing Estimates</h3>
-          <p>Line-item scopes and materials; virtual or on-site options.</p>
-          <div class="service-actions">
-            <a class="btn-solid" href="/services/real-estate/roof-estimates/">View Service</a>
-            <a class="btn-outline" href="/services/real-estate/">All Real Estate</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Visual Roof Inspections</h3>
-          <p>Walk-through with photos and a concise summary of findings.</p>
-          <div class="service-actions">
-            <a class="btn-solid" href="/services/real-estate/visual-inspections/">View Service</a>
-            <a class="btn-outline" href="/services/real-estate/">All Real Estate</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Roof Certifications</h3>
-          <p>1- or 2-year certification when the roof passes inspection.</p>
-          <div class="service-actions">
-            <a class="btn-solid" href="/services/real-estate/roof-certifications/">View Service</a>
-            <a class="btn-outline" href="/services/real-estate/">All Real Estate</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Insurance Consulting</h3>
-          <p>Claim strategy, adjuster-ready file prep, and optional on-site meets.</p>
-          <div class="service-actions">
-            <a class="btn-solid" href="/services/real-estate/insurance-consulting/">View Service</a>
-            <a class="btn-outline" href="/services/real-estate/">All Real Estate</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Professional Verbal Opinions</h3>
-          <p>Phone/Zoom consults with optional brief written summary.</p>
-          <div class="service-actions">
-            <a class="btn-solid" href="/services/real-estate/verbal-opinions/">View Service</a>
-            <a class="btn-outline" href="/services/real-estate/">All Real Estate</a>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <h3>Satellite Imagery Analysis</h3>
-          <p>Desk review with marked-up plans when roof access is limited.</p>
-          <div class="service-actions">
-            <a class="btn-solid" href="/services/real-estate/satellite-imagery-analysis/">View Service</a>
-            <a class="btn-outline" href="/services/real-estate/">All Real Estate</a>
-          </div>
-        </article>
-      </div>
-    </section>
-
-    <!-- Repairs & Inspections (general) -->
-    <section id="repairs" class="light-section">
+    <section id="residential" class="services-category">
       <div class="container">
-        <div class="section-kicker">Inspections & repairs</div>
-        <h2 class="section-title">Keep water out—fast</h2>
-        <div class="catalog-grid">
-          <article class="service-card">
-            <h3>Leak Diagnostics</h3>
-            <p>Find and fix root causes; photos included.</p>
-            <div class="service-actions">
-              <a class="btn-solid" href="/services/roof-repairs/">Go to Repairs</a>
-            </div>
-          </article>
-          <article class="service-card">
-            <h3>Skylight & Flashing Repairs</h3>
-            <p>Targeted fixes for common failure points.</p>
-            <div class="service-actions">
-              <a class="btn-solid" href="/services/roof-repairs/">Go to Repairs</a>
-            </div>
-          </article>
-          <article class="service-card">
-            <h3>Maintenance</h3>
-            <p>Extend roof life with periodic cleanups and detail tune-ups.</p>
-            <div class="service-actions">
-              <a class="btn-solid" href="/services/roof-repairs/">Go to Repairs</a>
-            </div>
-          </article>
+        <div class="services-category-heading">
+          <div>
+            <p class="services-section-label">Residential roofing</p>
+            <h2>Roofing systems for Southern California homes</h2>
+          </div>
+          <a href="/services/residential/">View Residential Roofing</a>
+        </div>
+        <div class="services-card-grid">
+          <article class="services-card"><h3>Residential Roofing</h3><p>Explore repair, maintenance and replacement services for tile, shingle and low-slope home roofs.</p><a href="/services/residential/">Learn More</a></article>
+          <article class="services-card"><h3>Asphalt Shingle Roofing</h3><p>Architectural shingle systems with coordinated underlayment, ventilation, flashings and ridge details.</p><a href="/services/residential/asphalt-shingles/">Learn More</a></article>
+          <article class="services-card"><h3>Tile Roofing</h3><p>Tile roof installation and system planning for concrete or clay profiles common across Southern California.</p><a href="/services/residential/tile-roof/">Learn More</a></article>
+          <article class="services-card"><h3>Tile Lift and Lay</h3><p>Carefully remove reusable tile, replace the underlayment and metals, then reinstall the existing tile.</p><a href="/services/residential/tile-lift-lay/">Learn More</a></article>
+          <article class="services-card"><h3>Residential TPO Roofing</h3><p>Reflective single-ply roofing for compatible low-slope home sections, additions and patio areas.</p><a href="/services/residential/tpo/">Learn More</a></article>
+          <article class="services-card"><h3>Residential Torch-Down Roofing</h3><p>Modified bitumen roofing for compatible low-slope areas requiring a durable multi-layer assembly.</p><a href="/services/residential/torch-down/">Learn More</a></article>
+          <article class="services-card"><h3>Residential Silicone Roof Coating</h3><p>Restore eligible low-slope roofs with preparation, reinforced details and a protective silicone coating.</p><a href="/services/residential/silicone/">Learn More</a></article>
         </div>
       </div>
     </section>
 
-    <!-- Estimate / Contact -->
-    <section id="estimate" class="container" style="padding:2rem 1rem;">
-      <h2 class="h3">Request an Estimate</h2>
-      <div data-include="/components/estimate-form.html"></div>
-      <p class="small muted" style="margin-top:.5rem">
-        <em>*Free estimates exclude certain real-estate transactions; ask about paid report options for escrow.</em>
-      </p>
+    <section id="commercial" class="services-category services-category-alt">
+      <div class="container">
+        <div class="services-category-heading">
+          <div>
+            <p class="services-section-label">Commercial roofing</p>
+            <h2>Commercial roof systems, maintenance and replacement</h2>
+          </div>
+          <a href="/services/commercial/">View Commercial Roofing</a>
+        </div>
+        <div class="services-card-grid">
+          <article class="services-card"><h3>Commercial Roofing</h3><p>Roofing services for commercial properties, including system selection, replacement, repair and maintenance.</p><a href="/services/commercial/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial TPO Roofing</h3><p>Heat-welded single-ply membrane systems for energy-conscious low-slope commercial roofs.</p><a href="/services/commercial/tpo/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial PVC Roofing</h3><p>Single-ply PVC roof systems for compatible commercial applications and demanding rooftop conditions.</p><a href="/services/commercial/pvc/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial Torch-Down Roofing</h3><p>Modified bitumen assemblies for commercial low-slope roofs, transitions and high-use rooftop areas.</p><a href="/services/commercial/torch-down/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial Silicone Coatings</h3><p>Restore eligible roofs with detailed preparation, reinforced seams and a high-solids silicone finish.</p><a href="/services/commercial/silicone-coatings/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial Metal Roofing</h3><p>Metal roof solutions and retrofit planning for compatible commercial and industrial buildings.</p><a href="/services/commercial/metal/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial Shingle Systems</h3><p>Shingle roof systems for offices, multifamily buildings and other steep-slope commercial properties.</p><a href="/services/commercial/shingle-systems/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial Tile Roofing</h3><p>Tile roofing services for commercial and multifamily properties with pitched roof sections.</p><a href="/services/commercial/tile-roofing/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial Roof Maintenance</h3><p>Planned inspections and maintenance that help property teams manage roof assets and reduce surprises.</p><a href="/services/commercial/roof-asset-maintenance/">Learn More</a></article>
+          <article class="services-card"><h3>Commercial Debris Removal</h3><p>Clear debris from roof surfaces and drainage areas to support safer, more reliable water flow.</p><a href="/services/commercial/debris-removal-cleaning/">Learn More</a></article>
+        </div>
+      </div>
+    </section>
+
+    <section id="claims" class="services-category">
+      <div class="container">
+        <div class="services-category-heading">
+          <div>
+            <p class="services-section-label">Insurance and storm response</p>
+            <h2>Documentation and emergency protection after roof damage</h2>
+          </div>
+          <a href="/services/insurance-claims/">View Insurance Claim Services</a>
+        </div>
+        <div class="services-card-grid">
+          <article class="services-card"><h3>Insurance Claim Roofing Services</h3><p>Understand the roofing scope, documentation and repair or replacement path after covered damage.</p><a href="/services/insurance-claims/">Learn More</a></article>
+          <article class="services-card"><h3>Storm Damage Inspection</h3><p>Document visible wind, rain or impact-related roof damage and identify immediate concerns.</p><a href="/services/insurance-claims/storm-damage/">Learn More</a></article>
+          <article class="services-card"><h3>Emergency Tarping and Dry-In</h3><p>Temporary weather protection designed to reduce additional water entry while permanent work is planned.</p><a href="/services/insurance-claims/emergency-tarping-dry-in/">Learn More</a></article>
+          <article class="services-card"><h3>Adjuster Support</h3><p>Roofing documentation and on-site support that help clarify observed conditions and the proposed scope.</p><a href="/services/insurance-claims/adjuster-support/">Learn More</a></article>
+          <article class="services-card"><h3>Insurance Claim Process Overview</h3><p>A plain-language guide to the roofing contractor’s role during a property insurance claim.</p><a href="/services/insurance-claims/overview/">Learn More</a></article>
+        </div>
+      </div>
+    </section>
+
+    <section id="real-estate" class="services-category services-category-alt">
+      <div class="container">
+        <div class="services-category-heading">
+          <div>
+            <p class="services-section-label">Real estate roof services</p>
+            <h2>Roof information for buyers, sellers and real estate professionals</h2>
+          </div>
+          <a href="/services/real-estate/">View Real Estate Services</a>
+        </div>
+        <div class="services-card-grid">
+          <article class="services-card"><h3>Real Estate Roofing Services</h3><p>Specialty roof inspections, reports, estimates and professional opinions for property transactions.</p><a href="/services/real-estate/">Learn More</a></article>
+          <article class="services-card"><h3>Roof Reports</h3><p>A written roof condition summary with observations, photos and recommended next steps when applicable.</p><a href="/services/real-estate/roof-reports/">Learn More</a></article>
+          <article class="services-card"><h3>Roof Estimates</h3><p>Repair or replacement estimates that help parties understand the likely roofing scope and cost.</p><a href="/services/real-estate/roof-estimates/">Learn More</a></article>
+          <article class="services-card"><h3>Visual Roof Inspections</h3><p>An on-site visual assessment with photos and a concise explanation of readily observable conditions.</p><a href="/services/real-estate/visual-inspections/">Learn More</a></article>
+          <article class="services-card"><h3>Roof Certifications</h3><p>Certification options for qualifying roofs after inspection and any required corrective work.</p><a href="/services/real-estate/roof-certifications/">Learn More</a></article>
+          <article class="services-card"><h3>Insurance Consulting</h3><p>Roof-related consulting and documentation support for property insurance questions and claim review.</p><a href="/services/real-estate/insurance-consulting/">Learn More</a></article>
+          <article class="services-card"><h3>Professional Verbal Opinions</h3><p>A direct conversation with a roofing professional when a full written report is not required.</p><a href="/services/real-estate/verbal-opinions/">Learn More</a></article>
+          <article class="services-card"><h3>Satellite Imagery Analysis</h3><p>Remote roof review using available aerial imagery when site access or timing is limited.</p><a href="/services/real-estate/satellite-imagery-analysis/">Learn More</a></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="services-faq">
+      <div class="container">
+        <p class="services-section-label">Common questions</p>
+        <h2>Choosing a roofing service</h2>
+        <div class="services-faq-list">
+          <details><summary>How do I know whether I need a roof repair or replacement?</summary><p>An inspection considers the roof’s age, material, leak history, damage pattern and remaining serviceable areas. Localized problems may be repairable. Widespread deterioration or repeated failures can make replacement the more practical option.</p></details>
+          <details><summary>What roofing systems does Zenith install and service?</summary><p>Zenith works with tile, asphalt shingles, TPO, PVC, torch-down modified bitumen, silicone restoration systems and commercial metal roofing. The right system depends on roof slope, drainage, building use and existing conditions.</p></details>
+          <details><summary>Do you provide both residential and commercial roofing?</summary><p>Yes. Zenith Roofing Services works on homes, multifamily properties and commercial buildings throughout its Southern California service area.</p></details>
+          <details><summary>Which areas do you serve?</summary><p>Zenith primarily serves San Diego County and Southwest Riverside County. Contact the team with the property address to confirm availability.</p></details>
+          <details><summary>Can you help if I am not sure which service to request?</summary><p>Yes. Start with a roof inspection or request an estimate and explain what you are seeing. The team can direct you to the appropriate repair, maintenance or replacement service.</p></details>
+        </div>
+      </div>
+    </section>
+
+    <section id="estimate" class="services-estimate">
+      <div class="container">
+        <div class="services-estimate-heading">
+          <p class="services-section-label">Request an estimate</p>
+          <h2>Tell us what your roof needs</h2>
+          <p>Share the property details and the roofing concern. Our team will review your request and contact you about the next step.</p>
+        </div>
+        <div data-include="/components/estimate-form.html"></div>
+        <p class="services-estimate-note"><em>Free estimates exclude certain real estate transactions. Ask about paid roof report and transaction service options.</em></p>
+      </div>
     </section>
   </main>
 
-  <!-- Footer -->
   <div data-include="/components/footer.html"></div>
-
-  <!-- Loader -->
   <script src="/js/loader.js" defer></script>
 
-  <!-- Scrollspy highlight for subnav -->
-  <script>
-    (function(){
-      const links=[...document.querySelectorAll('.catalog-subnav a')];
-      const secs=links.map(a=>document.querySelector(a.getAttribute('href')));
-      const setActive=()=>{
-        const top=scrollY+((parseInt(getComputedStyle(document.documentElement).getPropertyValue('--header-height'))||72)+16);
-        let idx=0; secs.forEach((s,i)=>{ if(s && s.offsetTop<=top) idx=i; });
-        links.forEach((a,i)=>a.classList.toggle('is-active', i===idx));
-      };
-      addEventListener('scroll', setActive, {passive:true}); setActive();
-    })();
-  </script>
-
-  <!-- JSON-LD ItemList for SEO -->
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
-    "@type":"ItemList",
-    "name":"Zenith Roofing Services - All Services",
-    "itemListElement":[
-      {"@type":"ListItem","position":1,"url":"https://zenithroofingservices.com/services/roof-replacement/","name":"Commercial & Residential Roof Replacement"},
-      {"@type":"ListItem","position":2,"url":"https://zenithroofingservices.com/services/roof-repairs/","name":"Roof Repairs"},
-      {"@type":"ListItem","position":3,"url":"https://zenithroofingservices.com/services/real-estate/","name":"Real Estate Services"},
-      {"@type":"ListItem","position":4,"url":"https://zenithroofingservices.com/services/commercial/tpo/","name":"TPO/PVC (Commercial)"},
-      {"@type":"ListItem","position":5,"url":"https://zenithroofingservices.com/services/commercial/torch-down/","name":"Modified Bitumen"},
-      {"@type":"ListItem","position":6,"url":"https://zenithroofingservices.com/services/commercial/silicone-coatings/","name":"Silicone Restoration"},
-      {"@type":"ListItem","position":7,"url":"https://zenithroofingservices.com/services/commercial/metal/","name":"Metal Retrofits"},
-      {"@type":"ListItem","position":8,"url":"https://zenithroofingservices.com/services/real-estate/roof-reports/","name":"Certified Roof Reports"},
-      {"@type":"ListItem","position":9,"url":"https://zenithroofingservices.com/services/real-estate/roof-estimates/","name":"Pre-Sale Roofing Estimates"},
-      {"@type":"ListItem","position":10,"url":"https://zenithroofingservices.com/services/real-estate/visual-inspections/","name":"Visual Roof Inspections"},
-      {"@type":"ListItem","position":11,"url":"https://zenithroofingservices.com/services/real-estate/roof-certifications/","name":"Roof Certifications"},
-      {"@type":"ListItem","position":12,"url":"https://zenithroofingservices.com/services/real-estate/insurance-consulting/","name":"Insurance Consulting"},
-      {"@type":"ListItem","position":13,"url":"https://zenithroofingservices.com/services/real-estate/verbal-opinions/","name":"Professional Verbal Opinions"},
-      {"@type":"ListItem","position":14,"url":"https://zenithroofingservices.com/services/real-estate/satellite-imagery-analysis/","name":"Satellite Imagery Analysis"}
+    "@graph":[
+      {
+        "@type":"BreadcrumbList",
+        "itemListElement":[
+          {"@type":"ListItem","position":1,"name":"Home","item":"https://zenithroofingservices.com/"},
+          {"@type":"ListItem","position":2,"name":"Roofing Services","item":"https://zenithroofingservices.com/services/"}
+        ]
+      },
+      {
+        "@type":"ItemList",
+        "name":"Zenith Roofing Services Directory",
+        "numberOfItems":8,
+        "itemListElement":[
+          {"@type":"ListItem","position":1,"name":"Roof Replacement","url":"https://zenithroofingservices.com/services/roof-replacement/"},
+          {"@type":"ListItem","position":2,"name":"Roof Repairs","url":"https://zenithroofingservices.com/services/roof-repairs/"},
+          {"@type":"ListItem","position":3,"name":"Roof Inspection","url":"https://zenithroofingservices.com/services/roof-inspection/"},
+          {"@type":"ListItem","position":4,"name":"Residential Roofing","url":"https://zenithroofingservices.com/services/residential/"},
+          {"@type":"ListItem","position":5,"name":"Commercial Roofing","url":"https://zenithroofingservices.com/services/commercial/"},
+          {"@type":"ListItem","position":6,"name":"Insurance Claim Roofing Services","url":"https://zenithroofingservices.com/services/insurance-claims/"},
+          {"@type":"ListItem","position":7,"name":"Rain Gutters","url":"https://zenithroofingservices.com/services/gutters/"},
+          {"@type":"ListItem","position":8,"name":"Real Estate Roofing Services","url":"https://zenithroofingservices.com/services/real-estate/"}
+        ]
+      },
+      {
+        "@type":"FAQPage",
+        "mainEntity":[
+          {"@type":"Question","name":"How do I know whether I need a roof repair or replacement?","acceptedAnswer":{"@type":"Answer","text":"An inspection considers the roof's age, material, leak history, damage pattern and remaining serviceable areas. Localized problems may be repairable. Widespread deterioration or repeated failures can make replacement the more practical option."}},
+          {"@type":"Question","name":"What roofing systems does Zenith install and service?","acceptedAnswer":{"@type":"Answer","text":"Zenith works with tile, asphalt shingles, TPO, PVC, torch-down modified bitumen, silicone restoration systems and commercial metal roofing."}},
+          {"@type":"Question","name":"Do you provide both residential and commercial roofing?","acceptedAnswer":{"@type":"Answer","text":"Yes. Zenith Roofing Services works on homes, multifamily properties and commercial buildings throughout its Southern California service area."}},
+          {"@type":"Question","name":"Which areas do you serve?","acceptedAnswer":{"@type":"Answer","text":"Zenith primarily serves San Diego County and Southwest Riverside County. Contact the team with the property address to confirm availability."}},
+          {"@type":"Question","name":"Can you help if I am not sure which service to request?","acceptedAnswer":{"@type":"Answer","text":"Yes. Start with a roof inspection or request an estimate and explain what you are seeing. The team can direct you to the appropriate repair, maintenance or replacement service."}}
+        ]
+      }
     ]
   }
   </script>


### PR DESCRIPTION
## Summary
- rebuild the Services directory with all 49 existing service pages organized by customer intent
- add concise service descriptions and clear Learn More links
- add responsive directory styling consistent with the updated Zenith site theme
- add ItemList and FAQ structured data for search and AI discovery
- preserve the existing service-page URLs and content

## Validation
- verified all 49 internal service links resolve to existing local pages
- validated JSON-LD syntax
- confirmed one H1 and 49 Learn More links
- parsed the HTML successfully
- ran `git diff --check`

## Scope
Only these files are changed:
- `services/index.html`
- `css/services-directory.css`

This is a draft for review and does not change the live site until merged.