### PR TITLE
Center commercial roof tune-up introduction

### DIFF
--- a/services/roof-repairs/roof-tune-up/index.html
+++ b/services/roof-repairs/roof-tune-up/index.html
@@ -77,7 +77,11 @@
       color:#c75f00; font-size:.8rem; font-weight:900; letter-spacing:.09em;
       margin:0 0 .35rem; text-transform:uppercase;
     }
-    .commercial-tuneup .intro{ max-width:78ch; }
+    .commercial-tuneup .intro{
+      max-width:78ch;
+      margin-left:auto;
+      margin-right:auto;
+    }
     .commercial-scope{
       display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px;
       margin:1.2rem 0;


### PR DESCRIPTION
## What changed

- Centered the constrained commercial roof tune-up introduction block within its section.
- Preserved the existing centered text alignment and responsive width.

## Root cause

The paragraphs had a `max-width`, but no automatic left and right margins. The text itself was centered inside a narrower block that remained aligned to the left.

## Validation

- `git diff --check` passes.
- The updated remote tree matches the new local committed tree.