### PR TITLE
Add full customer review archive

### DIFF
--- a/reviews/index.html
+++ b/reviews/index.html
@@ -93,9 +93,9 @@
   <main class="page revs" id="top" aria-label="Customer reviews">
     <!-- Hero -->
     <section class="hero card airy">
-      <span class="badge">Customer Reviews</span>
-      <h1 style="margin:10px 0 6px;">What Homeowners Say About Us</h1>
-      <p class="lede">Real customer feedback from Google, HomeAdvisor, Yelp, GuildQuality, Owens Corning, Angi, and Thumbtack for roofing projects across San Diego County and Temecula.</p>
+      <span class="badge">194 Reviews Across Trusted Platforms</span>
+      <h1 style="margin:10px 0 6px;">Established, Local and Proven by Our Customers</h1>
+      <p class="lede">Read the actual words customers shared about Zenith Roofing Services on Google, HomeAdvisor, Yelp, GuildQuality, Owens Corning, Angi and Thumbtack.</p>
 
       <!-- Source selector -->
       <div class="pills" role="toolbar" aria-label="Filter by source">
@@ -112,8 +112,8 @@
       <!-- Highlights (no averages) -->
       <div class="highlights" aria-label="Review highlights">
         <div class="kpi"><div>Across Our Profiles</div><strong>194 Reviews</strong></div>
-        <div class="kpi"><div>Google Reviews</div><strong>66 Combined</strong></div>
-        <div class="kpi"><div>Reviews Shown Below</div><strong id="totalCount">–</strong></div>
+        <div class="kpi"><div>Google Reviews</div><strong>58 Escondido • 8 Temecula</strong></div>
+        <div class="kpi"><div>Written Review Cards</div><strong id="totalCount">–</strong></div>
       </div>
 
       <!-- Quick filters -->
@@ -131,42 +131,42 @@
     <section class="cta-wrap" aria-label="Profile links">
       <div class="cta">
         <h3>Google — Escondido</h3>
-        <p class="muted">Our primary San Diego County profile.</p>
+        <p class="muted"><strong>58 reviews • 4.9 stars</strong><br>Our primary San Diego County profile.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://share.google/tu1mPk3Oim7OPFiqS">Open Escondido Profile</a>
       </div>
       <div class="cta">
         <h3>Google — Temecula</h3>
-        <p class="muted">Our Temecula Valley profile.</p>
+        <p class="muted"><strong>8 reviews • 5.0 stars</strong><br>Our Temecula Valley profile.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://share.google/2Ok3Yz6IHsJMdQvh3">Open Temecula Profile</a>
       </div>
       <div class="cta">
         <h3>HomeAdvisor</h3>
-        <p class="muted">62 homeowner ratings and reviews.</p>
+        <p class="muted"><strong>62 reviews • 4.9 stars</strong><br>Homeowner ratings and project feedback.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://www.homeadvisor.com/rated.ZenithRoofingServices.73340475.html">Open HomeAdvisor</a>
       </div>
       <div class="cta">
         <h3>Yelp</h3>
-        <p class="muted">See customer experiences & photos.</p>
+        <p class="muted"><strong>16 recommended reviews • 4.8 stars</strong><br>Customer experiences and project photos.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://www.yelp.com/biz/zenith-roofing-services-escondido">Open Yelp Profile</a>
       </div>
       <div class="cta">
         <h3>GuildQuality</h3>
-        <p class="muted">Verified, survey-based feedback.</p>
+        <p class="muted"><strong>19 verified reviews • 4.9 stars</strong><br>Independent, survey-based feedback.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://www.guildquality.com/profile/zenith-roofing-services">Open GuildQuality</a>
       </div>
       <div class="cta">
         <h3>Owens Corning</h3>
-        <p class="muted">Manufacturer partner profile.</p>
+        <p class="muted"><strong>19 reviews • 4.95 stars</strong><br>Manufacturer contractor profile.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828">Open OC Profile</a>
       </div>
       <div class="cta">
         <h3>Angi</h3>
-        <p class="muted">Customer feedback from completed projects.</p>
+        <p class="muted"><strong>9 reviews • 5.0 stars</strong><br>Customer feedback from completed projects.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://www.angi.com/companylist/us/ca/escondido/zenith-roofing-services-reviews-9533580.htm">Open Angi</a>
       </div>
       <div class="cta">
         <h3>Thumbtack</h3>
-        <p class="muted">5.0 rating from verified customers.</p>
+        <p class="muted"><strong>3 reviews • 5.0 stars</strong><br>Highly rated for value, responsiveness and quality.</p>
         <a class="btn primary" rel="noopener" target="_blank" href="https://www.thumbtack.com/ca/escondido/roofing/zenith-roofing-services-inc/service/295721236717715636">Open Thumbtack</a>
       </div>
     </section>
@@ -178,7 +178,7 @@
     <!-- Trust note -->
     <section class="card airy" style="margin-top:14px;">
       <h2>How we collect and display reviews</h2>
-      <p class="muted">The 194 total reflects review appearances across all listed profiles. Some feedback is syndicated or repeated across platforms, including HomeAdvisor/Angi and GuildQuality/Owens Corning. We show attributed excerpts below and link every platform so you can verify the original reviews.</p>
+      <p class="muted">The 194 total is the current sum of ratings and reviews across the eight profiles above. The written cards include the customer comments available publicly; ratings without comments do not create a card. Some feedback is syndicated across HomeAdvisor/Angi and GuildQuality/Owens Corning. Every card identifies its platform and links to the public source.</p>
     </section>
   </main>
 
@@ -256,7 +256,68 @@
       {"source":"angi","rating":5,"author":"Pete C.","location":"","date":"2018-08-01","body":"Arrived as scheduled, completed the promised work, and demonstrated excellent professionalism.","permalink":"https://www.angi.com/companylist/us/ca/escondido/zenith-roofing-services-reviews-9533580.htm"},
       {"source":"guildquality","rating":5,"author":"Alexander H.","location":"San Diego, CA","date":"2026-02-20","body":"Great service, strong communication, and quick completion from Bryan and the team.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
       {"source":"guildquality","rating":5,"author":"Simena W.","location":"San Diego, CA","date":"2026-02-15","body":"Satisfied with the service.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
-      {"source":"thumbtack","rating":5,"author":"Verified Thumbtack Customers","location":"Escondido, CA","date":"2024-06-19","body":"Customers rated Zenith highly for value, responsiveness, and work quality.","permalink":"https://www.thumbtack.com/ca/escondido/roofing/zenith-roofing-services-inc/service/295721236717715636"}
+      {"source":"thumbtack","rating":5,"author":"Verified Thumbtack Customers","location":"Escondido, CA","date":"2024-06-19","body":"Customers rated Zenith highly for value, responsiveness, and work quality.","permalink":"https://www.thumbtack.com/ca/escondido/roofing/zenith-roofing-services-inc/service/295721236717715636"},
+
+      {"source":"google","rating":5,"author":"Faye Hudson","location":"","date":"2026-04-01","body":"We were referred to Zenith through a strong referral from a friend and whose neighbors had also used them. Despite that, I still got 5 estimates just to make sure. They came in on the lower end of pricing (though not the lowest), but their work included more in the initial estimate. Bryan was thorough in his estimate, did not over-measure, and was fair about removing pricing from the quote when something did not need to happen. We had 2 layers of shingle on top of a layer of shake which made a mess of our open attic garage, but they protected everything and cleaned it all up as though nothing happened. The city where I live requires permits which they got and then passed the inspection. They kept us in the loop each day and provided lots of in-process photos. Thank you to Bryan and his team!","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"James Gardner","location":"","date":"2026-06-01","body":"Zenith Roofing is a great company to do business with from beginning to end. I needed a roofing company to do a tile lift and relay. The underlayment was going bad and deteriorating. Their roofing crew came out and did an excellent job.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Mike Farkas","location":"","date":"2023-07-18","body":"Zenith Roofing Services did an amazing job for us! We had to replace our very old roof with a new one so it was a pretty big undertaking. After meeting with a handful of other companies, we decided to go with Zenith Roofing because of their solid reputation, responsiveness, and very competitive pricing. From start to finish, Bryan remained involved and in close contact. The rest of his team was also very professional, courteous, and efficient. They took care of everything professionally and the project went smoothly. They cleaned up everything every day, and nothing was damaged or messed up. The roof looks wonderful and I would definitely recommend them.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Jaquone Williams","location":"","date":"2026-05-01","body":"My house has an older roof, and I expected most contractors to push for a full replacement. These guys actually suggested starting with targeted repairs first. They fixed cracked flashing, resealed joints, and reinforced a weak edge.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Dave Taylor","location":"","date":"2026-02-01","body":"Bryan and crew did a nice job inspecting our roof, finding the cause of our drainage issue, suggesting a solution, and then repairing the problem. They kept us updated as the job progressed, and they also provided us with photos before, during and after. Bryan and crew were always on-time. They even squeezed us on to their schedule so that the repair could be done before the heavy rains came—much appreciated!","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Vivian's Quality","location":"","date":"2025-02-07","body":"I called Zenith Roofing out to repair two leaks I had in the roof of my building. They came out and did a free inspection and the owner, who is extremely knowledgeable, gave me my options and explained the problem clearly and concisely so I could make a decision on how to proceed. They showed up on time and ready to work. Extremely professional, I will definitely use them again.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Yoko Wickersham","location":"","date":"2025-07-28","body":"I had an excellent experience with Zenith Roofing Services when a missing tile on my second-floor roof needed replacement. Brian's response was incredibly quick via both calls and texts. Despite my job being super small, Brian's attitude was very professional. His crew showed up promptly, quickly got to work and even took the initiative to check my entire roof. They found and replaced additional broken tiles on the spot. I will definitely use Zenith Roofing Services again and will enthusiastically recommend them to my clients and friends.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Eric Delatorre","location":"","date":"2024-07-15","body":"The quality of work is outstanding! The work was done in a timely manner. They were on time every day and ready to work. I would like to thank Bryan for the excellent work and attention to detail, and shout out to Bryan and the crew for working hard even on those hot days.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Jeffrey Powell","location":"","date":"2025-08-09","body":"Bryan was very helpful and had his crew out the same day to look at my roof. They let me know what needed to be done and had photos of everything. The job was done in a timely manner and everyone was very professional. I will absolutely be using Zenith again for all my roofing needs.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Gonzalo Guzman","location":"","date":"2026-02-01","body":"Zenith is a go-to contractor when it comes to roofing. They are punctual, clean and professional when it comes to their trade. Highly recommend!","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Pam Soggu","location":"","date":"2025-02-21","body":"Zenith was easy to work with and they did great work. I received three different quotes to remove and install new gutters around my house. Zenith was the only company that was able to provide an estimate without physically visiting the property, their rates were better than the other estimates I received, and they completed the work on time and within the budget. I would use Zenith for any future roofing needs and highly recommend them to others.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Pedro Alcazar","location":"","date":"2021-01-01","body":"Bryan and his team are extremely professional. The quality of work is top notch. Bryan did an excellent job communicating with me all of the work he was doing and prepared me for any sort of unseen issues that might arise.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Roxy Mueller","location":"","date":"2023-01-01","body":"Bryan and his team were fantastic and we are totally happy with the quality and professionalism Zenith put forward every day. Our roof was a challenge, but the team worked quickly to solve each problem, often providing options to choose from.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Nicholas Sites","location":"","date":"2024-04-06","body":"Bryan and his team did an amazing job on my roof replacement. My roof had about two years left on it and we were getting solar, so we decided to get a new roof beforehand. Bryan came out quickly to provide an estimate.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Kevin Alarcon","location":"","date":"2022-01-01","body":"Zenith Roofing was an outstanding value. It was great to find quality service at a good price. As a customer it can be scary trusting such a major project to someone, but Bryan was outstanding to work with. I would recommend them.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Tim Parillo","location":"","date":"2023-04-27","body":"Bryan and his crew did a great job removing and replacing a section of our very delicate clay tile roof. It was tricky work, given the nature of aged tiles. They did it perfectly, including closing off some openings in the original sheathing that had been done poorly by a former owner. Highly recommend.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Chandra Shah","location":"","date":"2022-01-01","body":"Bryan and his team worked very sincerely and finished work in time and used all good material. They are very professional and courteous. Bryan is an honest and knowledgeable owner of the company.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Lance Parrow","location":"","date":"2025-01-01","body":"A really good experience. Bryan and Omar are great company representatives. Fair price, quality work, and overall very satisfied.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"K & R Kalahiki","location":"","date":"2024-08-20","body":"Bryan and his team did a great job, always on time, super clean, efficient and even saved us money in the end. We'd give them a 10!","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Robert Caires","location":"","date":"2026-01-01","body":"Great work. Great price. Friendly workers.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Salomeh Barati","location":"","date":"2024-01-01","body":"Bryan and his team were great! Very fair and the job was well done. Highly recommend them. Thank you!","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"NYY Fan","location":"","date":"2021-01-01","body":"They are a reputable company with honest employees. They do what they say they are going to do and complete it on time. Very professional, with great people skills. Once they started the job, they showed up every day until completion, just as they said they would. I would hire them again.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Darlene Ralls","location":"","date":"2026-07-15","body":"Zenith Roofing refurbished our roof by replacing all the broken and cracked tile, replaced the underlayment and replaced all the flashing around the skylights and many tube lights on our 30-year-old roof, plus extra. There was no pressure.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Katherine Stout","location":"","date":"2023-01-01","body":"Wonderful service! Fixed perfect! Bryan is so friendly and a real professional!","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Harry Koch","location":"","date":"2021-01-01","body":"Great job, very friendly crew. Will definitely recommend them and use them again in the future.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Samuel Luna","location":"","date":"2021-01-01","body":"Bryan was professional and responsive. I highly recommend them.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Marcel Tabar","location":"","date":"2023-01-01","body":"Excellent.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+      {"source":"google","rating":5,"author":"Thiago Calixto","location":"","date":"2021-01-01","body":"Great service.","permalink":"https://share.google/tu1mPk3Oim7OPFiqS"},
+
+      {"source":"google","rating":5,"author":"Joshua Francis","location":"Temecula, CA","date":"2026-01-01","body":"5-star work. Came on short notice to evaluate a leak, provided multiple quotes, gave an honest opinion and completed the work within a few days.","permalink":"https://share.google/2Ok3Yz6IHsJMdQvh3"},
+      {"source":"google","rating":5,"author":"Alisha Stoll","location":"Temecula, CA","date":"2024-01-01","body":"Upon the purchase of our home, the inspection identified some broken Spanish roof tiles. We were referred to Bryan and his team at Zenith and now we won't use anyone else. His price was reasonable and communication is great. Always there when he says and his quality of service and follow-up could not be better. Zenith has lifetime customers in us!","permalink":"https://share.google/2Ok3Yz6IHsJMdQvh3"},
+      {"source":"google","rating":5,"author":"David","location":"Temecula, CA","date":"2025-01-01","body":"From quote to install, I got a few estimates and they were competitive on price—certainly who I felt the most comfortable using. Zenith's service was through the roof! Thank you Bryan and Krystal.","permalink":"https://share.google/2Ok3Yz6IHsJMdQvh3"},
+      {"source":"google","rating":5,"author":"Chad Brinkman","location":"Temecula, CA","date":"2024-01-01","body":"Bryan is professional and gets the job done right with the best product on the market. Zenith is a great company with good people!","permalink":"https://share.google/2Ok3Yz6IHsJMdQvh3"},
+      {"source":"google","rating":5,"author":"Michelle Sapena","location":"Temecula, CA","date":"2025-09-01","body":"Great job on my roof—professional, quick, and quality work. Highly recommend!","permalink":"https://share.google/2Ok3Yz6IHsJMdQvh3"},
+      {"source":"google","rating":5,"author":"Kevin Alarcon","location":"Temecula, CA","date":"2024-01-01","body":"If you want quality work at good prices, reach out to Bryan and his crew. Couldn't be happier with our new roof and the process.","permalink":"https://share.google/2Ok3Yz6IHsJMdQvh3"},
+      {"source":"google","rating":5,"author":"Uriel Garcia","location":"Temecula, CA","date":"2024-01-01","body":"Very nice work! I'm happy with all I needed done. Very professional and on time! Thank you Zenith.","permalink":"https://share.google/2Ok3Yz6IHsJMdQvh3"}
+      ,
+      {"source":"guildquality","rating":5,"author":"Alexander H.","location":"San Diego, CA","date":"2026-02-20","body":"Great service from Bryan and his team. They were incredibly communicative throughout the entire process and worked quickly to get the job done.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Simena W.","location":"San Diego, CA","date":"2026-02-15","body":"Satisfied with the service.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Renatte A.","location":"San Diego, CA","date":"2025-05-14","body":"The owner was extremely informative during the estimation process, and always responsive to every question I had. More importantly, his expertise and professionalism made me feel comfortable after I had had two different roofs from two different companies that leaked. Zenith offered the clearest itemization and best value for a good product. The crew manager and workers put in consistent effort, kept me informed and were respectful of my property. Each stage was completed in the time frame as promised, and I did not feel I was being hit with up-charges since all aspects of the process had been well laid-out and upfront.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Barbara P.","location":"San Diego, CA","date":"2025-04-23","body":"I found Zenith Roofing Services to be very professional. Bryan and Omar knew their stuff. The company had their license, contract, and a description of what would take place during the work. They are very knowledgeable and pleasant to work with. I would recommend them without hesitation.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Review in Temecula, CA","location":"Temecula, CA","date":"2025-03-19","body":"Bryan Ramirez from Zenith Roofing provided excellent customer service and a quality roof replacement.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Laurie W.","location":"Escondido, CA","date":"2025-01-09","body":"Zenith was excellent to work with from beginning to end, from quote to job completed.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Janet R.","location":"Temecula, CA","date":"2024-10-23","body":"Zenith Roofing Services did a good job. Their communication was great, and they were on time. Zenith Roofing Services let me know when they would arrive and never left me waiting. Zenith Roofing Services provided a good response, and I liked that.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Marco C.","location":"San Diego, CA","date":"2024-04-24","body":"Courteous, on time and on schedule as advertised.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Steven L.","location":"San Diego, CA","date":"2023-01-05","body":"Working with Zenith was smooth and easy; they go the extra mile to make sure everything was right.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Barbara F.","location":"San Diego, CA","date":"2022-10-30","body":"Zenith Roofing was professional and proactive. I was impressed when they did a previous repair on my old roof. They were very aware of ways to make the roof more insulated for our weather. They were up on current and cutting-edge practices.","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+      {"source":"guildquality","rating":5,"author":"Evette F.","location":"Poway, CA","date":"2021-02-25","body":"Bryan answered all of my questions and was straightforward! He came on time and gave me an estimate of what I asked for. The price was so reasonable. They were fantastic! I was very pleased with them!","permalink":"https://www.guildquality.com/profile/zenith-roofing-services"},
+
+      {"source":"owens","rating":5,"author":"Alexander H.","location":"San Diego, CA","date":"2026-02-20","body":"Great service from Bryan and his team. They were incredibly communicative throughout the entire process and worked quickly to get the job done.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Simena W.","location":"San Diego, CA","date":"2026-02-15","body":"Satisfied with the service.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Renatte A.","location":"San Diego, CA","date":"2025-05-14","body":"The owner was extremely informative during the estimation process and always responsive to every question I had. Zenith offered the clearest itemization and best value. The crew kept me informed, respected my property and completed each stage in the promised time frame.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Barbara P.","location":"San Diego, CA","date":"2025-04-23","body":"I found Zenith Roofing Services to be very professional. Bryan and Omar knew their stuff. They are very knowledgeable and pleasant to work with. I would recommend them without hesitation.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Review in Temecula, CA","location":"Temecula, CA","date":"2025-03-19","body":"Bryan Ramirez from Zenith Roofing provided excellent customer service and a quality roof replacement.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Laurie W.","location":"Escondido, CA","date":"2025-01-09","body":"Zenith was excellent to work with from beginning to end, from quote to job completed.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Janet R.","location":"Temecula, CA","date":"2024-10-23","body":"Zenith Roofing Services did a good job. Their communication was great, and they were on time. They let me know when they would arrive and never left me waiting.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Marco C.","location":"San Diego, CA","date":"2024-04-24","body":"Courteous, on time and on schedule as advertised.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Steven L.","location":"San Diego, CA","date":"2023-01-05","body":"Working with Zenith was smooth and easy; they go the extra mile to make sure everything was right.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Barbara F.","location":"San Diego, CA","date":"2022-10-30","body":"Zenith Roofing was professional and proactive. They were aware of ways to make the roof more insulated for our weather and were up on current and cutting-edge practices.","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"},
+      {"source":"owens","rating":5,"author":"Evette F.","location":"Poway, CA","date":"2021-02-25","body":"Bryan answered all of my questions and was straightforward. He came on time and gave me an estimate of what I asked for. The price was so reasonable. They were fantastic!","permalink":"https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828"}
     ]
   }
   </script>
@@ -266,7 +327,15 @@
     const $$$ = (q, el=document)=>Array.from(el.querySelectorAll(q));
 
     function loadReviews(){
-      try{ return JSON.parse($$('#reviews-seed').textContent).reviews || []; }
+      try{
+        const raw = JSON.parse($$('#reviews-seed').textContent).reviews || [];
+        const unique = new Map();
+        raw.forEach(review=>{
+          const key = [review.source, review.author, review.location || ''].join('|').toLowerCase();
+          unique.set(key, review);
+        });
+        return Array.from(unique.values());
+      }
       catch(e){ return []; }
     }
     function starText(n){ const full = Math.round(n); return '★'.repeat(full) + '☆'.repeat(5-full); }


### PR DESCRIPTION
## What changed

- rebuilds the review-page headline around the defensible claim of **194 reviews across eight public profiles**
- shows the complete platform breakdown: 58 Escondido Google, 8 Temecula Google, 62 HomeAdvisor, 16 Yelp, 19 GuildQuality, 19 Owens Corning, 9 Angi, and 3 Thumbtack
- expands the page from 62 to 107 written review cards
- replaces short marketing summaries with customer wording collected from the public profiles
- retains source filters, search, star filtering, pagination, and direct verification links
- explains ratings without comments and syndicated review duplication

## Why

The earlier version showed profile totals but did not include enough of the actual written customer feedback to demonstrate Zenith Roofing Services’ established review history.

## Validation

- parsed the embedded review data successfully
- verified 107 unique written cards after duplicate handling
- confirmed the eight-profile total equals 194
- ran `git diff --check` with no errors