### PR TITLE
Port exact Zenith premium design into the real site

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -25,38 +25,6 @@
   <script defer src="/js/loader.js"></script>
   <script defer src="/js/header.js"></script>
 
-  <!-- Page micro styles -->
-  <style>
-    html { scroll-behavior: smooth; }
-    .page.about { max-width:1080px; margin:24px auto; padding:0 16px; }
-    .hero { background:linear-gradient(135deg,#f8fafc,#eef6ff); border:1px solid var(--ui-line); border-radius:18px; padding:clamp(18px,3vw,28px); box-shadow:0 14px 34px rgba(2,12,32,.08); }
-    .hero .chips { display:flex; flex-wrap:wrap; gap:8px; margin:.25rem 0 .5rem; }
-    .chip { border:1px solid var(--ui-line); border-radius:999px; padding:.45rem .75rem; background:#fff; font-weight:800; }
-    .values-grid { display:grid; gap:16px; grid-template-columns:1fr; }
-    @media(min-width:860px){ .values-grid { grid-template-columns:repeat(3,1fr); } }
-    .quote { font-size:1.05rem; line-height:1.7; color:#0f172a; }
-    .sig { font-weight:800; color:#072e59; }
-    .badge-row { display:flex; flex-wrap:wrap; gap:10px; }
-    .badge-row .badge { background:#fff; border:1px solid var(--ui-line); border-radius:999px; padding:.45rem .75rem; font-weight:700; }
-    .media.placeholder {
-      background: linear-gradient(135deg, rgba(7,46,89,.06), rgba(247,148,29,.06));
-      border:1px dashed var(--ui-line);
-      border-radius:14px; height:230px;
-      display:flex; align-items:center; justify-content:center; color:#64748b; font-weight:700;
-    }
-    .cta-strip {
-      background:#072e59; color:#fff; border-radius:16px;
-      padding:16px; display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between;
-      box-shadow:0 14px 34px rgba(2,12,32,.12);
-    }
-    .cta-strip .btn { background:#f7941d; color:#0b0b0b; }
-    .btn { display:inline-flex; align-items:center; justify-content:center; padding:10px 16px; border-radius:12px; font-weight:800; text-decoration:none; border:2px solid transparent; }
-    .btn:hover { transform: translateY(-1px); box-shadow:0 10px 20px rgba(2,12,32,.08); }
-    .btn.outline { background:transparent; border-color:#f7941d; color:#f7941d; }
-    .list-tight { margin:.25rem 0 0 1rem; }
-    .list-tight li { margin:.2rem 0; }
-  </style>
-
   <!-- JSON-LD: Organization + Breadcrumbs -->
   <script type="application/ld+json">
   {
@@ -91,110 +59,120 @@
   <!-- Header include -->
   <div data-include="/components/header-section.html"></div>
 
-  <main id="top" class="page about">
-    <!-- HERO -->
-    <section class="hero card airy">
-      <div class="chips">
-        <span class="chip">Escondido-Born</span>
-        <span class="chip">San Diego Proud</span>
-        <span class="chip">Do It Right the First Time</span>
-      </div>
-      <h1>Built in San Diego. Built to Last.</h1>
-      <p class="lede">
-        We’re a local, family-run roofing company out of <strong>Escondido</strong> serving all of <strong>North County San Diego</strong>, greater <strong>San Diego</strong>, and <strong>Temecula Valley</strong>. 
-        Our promise is simple: use <strong>high-quality materials</strong>, follow manufacturer standards, document our work with photos, and leave your home <strong>water-tight, safe,</strong> and clean.
-      </p>
-      <div class="badge-row" aria-label="Trust highlights">
-        <span class="badge">Premium Materials</span>
-        <span class="badge">Manufacturer Warranties</span>
-        <span class="badge">Wind/Insurance Assessments</span>
-        <span class="badge">Jobsite Cleanliness</span>
-        <span class="badge">Photo Documentation</span>
-        <span class="badge">Great Communication</span>
-      </div>
-      <div class="cta" style="margin-top:12px; display:flex; gap:10px; flex-wrap:wrap;">
-        <a class="btn" href="/">Go to Home</a>
-        <a class="btn outline" href="/services/">Explore Services</a>
+  <main id="top" class="zr-about-page">
+    <section class="zr-interior-hero" aria-labelledby="about-title">
+      <img src="/images/zenith-van-optimized.jpg" width="1000" height="750" alt="Zenith Roofing Services work van at a Southern California project" fetchpriority="high">
+      <span class="zr-interior-hero__shade" aria-hidden="true"></span>
+      <div class="zr-shell zr-interior-hero__content">
+        <span class="zr-eyebrow zr-eyebrow--light">Licensed • Insured • Documented</span>
+        <h1 id="about-title">A roofing company built around clear work.</h1>
+        <p>Zenith Roofing Services helps homeowners, HOAs, property managers, and businesses make confident roofing decisions through clear scopes, dependable workmanship, and photo documentation.</p>
+        <div class="zr-interior-hero__actions">
+          <a class="zr-button zr-button--orange" href="/contact/">Request a Free Estimate <span aria-hidden="true">→</span></a>
+          <a class="zr-button zr-button--glass" href="tel:8589006163">Call 858-900-6163</a>
+        </div>
       </div>
     </section>
 
-    <!-- ASPIRATION / LIFESTYLE (≈70%) -->
-    <section class="section card airy hoverable">
-      <div class="grid cols-2">
-        <div>
-          <h2>Homes That Feel Buttoned-Up</h2>
-          <p class="quote">
-            A great roof isn’t just about shingles or tiles—it’s about peace of mind when the wind picks up and the rain sets in. 
-            We design and install like your home is our own, focusing on resilience, clean details, and a finish that looks as good as it performs.
-          </p>
-          <ul class="checklist relaxed">
-            <li><span class="tick">✓</span> Clean lines, correct flashings, and watertight transitions</li>
-            <li><span class="tick">✓</span> Roof systems that meet or exceed <em>manufacturer specs</em></li>
-            <li><span class="tick">✓</span> Before/after photos so you see exactly what we did</li>
-            <li><span class="tick">✓</span> Jobsite protection, daily cleanup, on-site dump trailers</li>
+    <div class="zr-interior-trust" aria-label="Zenith Roofing service standards">
+      <div class="zr-shell zr-interior-trust__grid">
+        <span><b>Licensed C-39</b><small>CSLB #1036112</small></span>
+        <span><b>Photo documented</b><small>Clear proof at every phase</small></span>
+        <span><b>194 customer reviews</b><small>Across trusted platforms</small></span>
+        <span><b>Locally established</b><small>Serving Southern California</small></span>
+      </div>
+    </div>
+
+    <section class="zr-section zr-about-intro">
+      <div class="zr-shell zr-about-proof">
+        <div class="zr-about-copy">
+          <span class="zr-eyebrow">About Zenith Roofing Services, Inc.</span>
+          <h2>San Diego &amp; Temecula roofing experts.</h2>
+          <p>We are a licensed Southern California roofing contractor serving residential and commercial properties with roof replacement, roof repair, tile, shingle, TPO, torch-down, silicone coatings, maintenance, and inspections.</p>
+          <p>Our process is straightforward: inspect thoroughly, scope clearly, install precisely, and document the work. The result is a better customer experience and a roofing system that is easier to understand from the start.</p>
+          <div class="zr-about-values" aria-label="Our working values">
+            <span><b>Clear</b> Line-item recommendations and practical options.</span>
+            <span><b>Documented</b> Photos before, during, and after the work.</span>
+            <span><b>Dependable</b> Clean sites, quality control, and communication.</span>
+          </div>
+        </div>
+        <div class="zr-about-visual">
+          <picture>
+            <source media="(max-width: 540px)" srcset="/images/zenith-sign-forklift-480.webp">
+            <source media="(max-width: 900px)" srcset="/images/zenith-sign-forklift-720.webp">
+            <img src="/images/zenith-sign-forklift.jpg" width="1440" height="1440" alt="Zenith Roofing Services sign at an active roofing jobsite" loading="lazy">
+          </picture>
+          <div class="zr-about-license">
+            <strong>CSLB #1036112</strong>
+            <span>California licensed C-39 roofing contractor.</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="zr-section zr-about-roots" aria-labelledby="roots-title">
+      <div class="zr-shell">
+        <div class="zr-section-heading">
+          <div>
+            <span class="zr-eyebrow">Local roots. Professional standards.</span>
+            <h2 id="roots-title">Built here. Accountable here.</h2>
+          </div>
+          <p>Zenith was built in Escondido by people who understand Southern California roofs, weather, neighborhoods, and the trust it takes to work on someone’s home.</p>
+        </div>
+        <div class="zr-roots-grid">
+          <article>
+            <span class="zr-card-number">01</span>
+            <h3>San Diego roots</h3>
+            <p>Born and raised in San Diego County, our owner built the company in Escondido and has lived here all his life. We know the microclimates, winds, and conditions local roofs face.</p>
+          </article>
+          <article>
+            <span class="zr-card-number">02</span>
+            <h3>Hands-on leadership</h3>
+            <p>We learned the craft by doing the work. That field experience shapes how our team plans details, communicates clearly, and keeps every project moving smoothly.</p>
+          </article>
+          <article>
+            <span class="zr-card-number">03</span>
+            <h3>Faith &amp; family</h3>
+            <p>We are a family that loves God and strives to be worthy of trust. Doing the right thing—even when no one is watching—is part of how we run the company.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="zr-section zr-about-standard">
+      <div class="zr-shell zr-standard-grid">
+        <div class="zr-standard-copy">
+          <span class="zr-eyebrow zr-eyebrow--light">The Zenith standard</span>
+          <h2>Work you can see. Details you can trust.</h2>
+          <p>A great roof is more than shingles or tile. It is correct flashing, watertight transitions, clean lines, manufacturer-approved installation, and the confidence of knowing what happened at every stage.</p>
+          <ul>
+            <li><span>✓</span><div><b>Clear recommendations</b><small>Practical options explained without pressure.</small></div></li>
+            <li><span>✓</span><div><b>Real photo documentation</b><small>Before, during, and after photos of the work.</small></div></li>
+            <li><span>✓</span><div><b>Protected, clean jobsites</b><small>Daily cleanup and respect for your property.</small></div></li>
+            <li><span>✓</span><div><b>One capable local team</b><small>Repairs, replacements, tile, flat roofing, gutters, skylights, and more.</small></div></li>
           </ul>
+          <a class="zr-text-link" href="/projects/">See real Zenith roofing projects <span aria-hidden="true">→</span></a>
         </div>
+        <a class="zr-standard-photo" href="/projects/" aria-label="View completed Zenith roofing projects">
+          <img src="/images/modern-tile-roof-1280.webp" width="1280" height="853" alt="Completed modern tile roof by Zenith Roofing Services" loading="lazy">
+          <span><small>Real project photography</small><b>Built for Southern California</b></span>
+        </a>
+      </div>
+    </section>
+
+    <section class="zr-section zr-about-service-area" aria-labelledby="area-title">
+      <div class="zr-shell zr-area-card">
         <div>
-          <figure class="media placeholder">Add a team / jobsite photo (1200×700)</figure>
-          <p class="muted small" style="margin:.4rem 0 0;">Want help deciding roof type or scope? We’ll walk you through options (performance, look, and cost) with no pressure.</p>
+          <span class="zr-eyebrow">Proudly serving Southern California</span>
+          <h2 id="area-title">Local roofing expertise, from San Diego to Temecula.</h2>
         </div>
-      </div>
-    </section>
-
-    <!-- STORY / HERITAGE / CRAFT (≈20%) -->
-    <section class="section">
-      <div class="values-grid">
-        <div class="card airy">
-          <h3>San Diego Roots</h3>
-          <p class="muted">Born and raised in San Diego County, our owner built the company in <strong>Escondido</strong> and has lived here all his life. We know the microclimates, the winds, and what SoCal roofs really face.</p>
+        <div class="zr-area-list" aria-label="Primary service areas">
+          <span>Escondido</span><span>North County</span><span>San Diego</span><span>Temecula</span><span>Murrieta</span><span>Menifee</span>
         </div>
-        <div class="card airy">
-          <h3>From Hands-On to Leadership</h3>
-          <p class="muted">We’ve worked on roofs ourselves, learned the craft the right way, and built a team known for <strong>precision</strong> and <strong>communication</strong>. That’s how we keep projects smooth.</p>
+        <div class="zr-area-actions">
+          <a class="zr-button zr-button--orange" href="/contact/">Request an Estimate <span aria-hidden="true">→</span></a>
+          <a class="zr-button zr-button--outline" href="/services/">Explore Services</a>
         </div>
-        <div class="card airy">
-          <h3>Guided by Faith & Family</h3>
-          <p class="muted">We’re a family that loves God and strives to be worthy of trust. Doing things right—even when no one’s watching—matters to us.</p>
-        </div>
-      </div>
-    </section>
-
-    <!-- TRUST / PROOF -->
-    <section class="section card airy hoverable">
-      <h2>Why Homeowners Choose Us</h2>
-      <ul class="checklist grid-2">
-        <li><span class="tick">✓</span> <strong>Insurance & Wind Damage</strong>—we assess storm and wind claims and help you communicate with carriers.</li>
-        <li><span class="tick">✓</span> <strong>Reviews You Can Verify</strong>—plenty on Google, Angi, and Yelp.</li>
-        <li><span class="tick">✓</span> <strong>Manufacturer Focus</strong>—we follow specs so warranties stay strong.</li>
-        <li><span class="tick">✓</span> <strong>All Services, One Team</strong>—repairs, tune-ups, tile lift & relay, TPO, silicone, gutters, skylights, and more.</li>
-      </ul>
-      <p class="muted small" style="margin:.4rem 0 0;">Ask us for sample photo sets—before, during, and after—so you can see our process.</p>
-    </section>
-
-    <!-- LIGHT SELL (≈10%) -->
-    <section class="section cta-strip">
-      <div class="text">
-        <strong>Ready to feel confident about your roof?</strong> We’ll show recommendations, materials, and photos—no guesswork.
-      </div>
-      <div class="actions" style="display:flex; gap:10px; flex-wrap:wrap;">
-        <a class="btn" href="/">Go to Home</a>
-        <a class="btn outline" href="/services/">Browse Services</a>
-      </div>
-    </section>
-
-    <!-- Service area & quick links -->
-    <section class="section card airy">
-      <h2>Proudly Serving</h2>
-      <p class="muted">North County San Diego, greater San Diego County, and Temecula Valley.</p>
-      <ul class="list-tight">
-        <li>Escondido • San Marcos • Carlsbad • Encinitas • Vista • Oceanside</li>
-        <li>San Diego metro • Poway • Rancho Bernardo • La Jolla • Scripps Ranch</li>
-        <li>Temecula • Murrieta • Menifee • Lake Elsinore</li>
-      </ul>
-      <div class="cta" style="margin-top:10px; display:flex; gap:10px; flex-wrap:wrap;">
-        <a class="btn" href="/">Return Home</a>
-        <a class="btn outline" href="/contact/">Contact</a>
-        <a class="btn outline" href="/services/">All Services</a>
       </div>
     </section>
   </main>
@@ -202,11 +180,5 @@
   <!-- Footer include -->
   <div data-include="/components/footer.html"></div>
 
-  <!-- Optional mobile action bar -->
-  <div class="actionbar">
-    <a class="ab-btn call" href="tel:8589006163">Call</a>
-    <a class="ab-btn text" href="sms:+18589006163">Text</a>
-    <a class="ab-btn estimate" href="/">Home</a>
-  </div>
 </body>
 </html>

--- a/about/index.html
+++ b/about/index.html
@@ -59,23 +59,23 @@
   <!-- Header include -->
   <div data-include="/components/header-section.html"></div>
 
-  <main id="top" class="zr-about-page">
-    <section class="zr-interior-hero" aria-labelledby="about-title">
-      <img src="/images/zenith-van-optimized.jpg" width="1000" height="750" alt="Zenith Roofing Services work van at a Southern California project" fetchpriority="high">
-      <span class="zr-interior-hero__shade" aria-hidden="true"></span>
-      <div class="zr-shell zr-interior-hero__content">
-        <span class="zr-eyebrow zr-eyebrow--light">Licensed • Insured • Documented</span>
-        <h1 id="about-title">A roofing company built around clear work.</h1>
+  <main id="main-content" class="premium-page">
+    <section class="interior-hero">
+      <img src="/images/zenith-van-optimized.jpg" alt="Zenith Roofing Services work van at a Southern California project" width="1000" height="750" fetchpriority="high">
+      <span class="interior-hero__shade" aria-hidden="true"></span>
+      <div class="shell interior-hero__content">
+        <span class="eyebrow eyebrow--light">Licensed • Insured • Documented</span>
+        <h1>A roofing company built around clear work.</h1>
         <p>Zenith Roofing Services helps homeowners, HOAs, property managers, and businesses make confident roofing decisions through clear scopes, dependable workmanship, and photo documentation.</p>
-        <div class="zr-interior-hero__actions">
-          <a class="zr-button zr-button--orange" href="/contact/">Request a Free Estimate <span aria-hidden="true">→</span></a>
-          <a class="zr-button zr-button--glass" href="tel:8589006163">Call 858-900-6163</a>
+        <div class="interior-hero__actions">
+          <a class="button button--orange" href="/contact/">Request a Free Estimate <span aria-hidden="true">→</span></a>
+          <a class="button button--glass" href="tel:8589006163">Call 858-900-6163</a>
         </div>
       </div>
     </section>
 
-    <div class="zr-interior-trust" aria-label="Zenith Roofing service standards">
-      <div class="zr-shell zr-interior-trust__grid">
+    <div class="interior-trust" aria-label="Zenith service standards">
+      <div class="shell interior-trust__grid">
         <span><b>Licensed C-39</b><small>CSLB #1036112</small></span>
         <span><b>Photo documented</b><small>Clear proof at every phase</small></span>
         <span><b>194 customer reviews</b><small>Across trusted platforms</small></span>
@@ -83,95 +83,25 @@
       </div>
     </div>
 
-    <section class="zr-section zr-about-intro">
-      <div class="zr-shell zr-about-proof">
-        <div class="zr-about-copy">
-          <span class="zr-eyebrow">About Zenith Roofing Services, Inc.</span>
+    <section class="section">
+      <div class="shell proof-layout about-layout">
+        <div class="proof-copy">
+          <span class="eyebrow">About Zenith Roofing Services, Inc.</span>
           <h2>San Diego &amp; Temecula roofing experts.</h2>
-          <p>We are a licensed Southern California roofing contractor serving residential and commercial properties with roof replacement, roof repair, tile, shingle, TPO, torch-down, silicone coatings, maintenance, and inspections.</p>
+          <p>We are a licensed Southern California roofing contractor (CSLB #1036112, C-39) serving residential and commercial properties with roof replacement, roof repair, tile, shingle, TPO, torch-down, silicone coatings, maintenance, and inspections.</p>
           <p>Our process is straightforward: inspect thoroughly, scope clearly, install precisely, and document the work. The result is a better customer experience and a roofing system that is easier to understand from the start.</p>
-          <div class="zr-about-values" aria-label="Our working values">
-            <span><b>Clear</b> Line-item recommendations and practical options.</span>
-            <span><b>Documented</b> Photos before, during, and after the work.</span>
-            <span><b>Dependable</b> Clean sites, quality control, and communication.</span>
+          <div class="about-values">
+            <span><b>Clear</b>Line-item recommendations and practical options.</span>
+            <span><b>Documented</b>Photos before, during, and after the work.</span>
+            <span><b>Dependable</b>Clean sites, quality control, and communication.</span>
           </div>
         </div>
-        <div class="zr-about-visual">
-          <picture>
-            <source media="(max-width: 540px)" srcset="/images/zenith-sign-forklift-480.webp">
-            <source media="(max-width: 900px)" srcset="/images/zenith-sign-forklift-720.webp">
-            <img src="/images/zenith-sign-forklift.jpg" width="1440" height="1440" alt="Zenith Roofing Services sign at an active roofing jobsite" loading="lazy">
-          </picture>
-          <div class="zr-about-license">
+        <div class="proof-visual">
+          <img src="/images/zenith-sign-forklift.jpg" alt="Zenith Roofing Services jobsite" width="1440" height="1440" loading="lazy">
+          <div class="proof-visual__card">
             <strong>CSLB #1036112</strong>
             <span>California licensed C-39 roofing contractor.</span>
           </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="zr-section zr-about-roots" aria-labelledby="roots-title">
-      <div class="zr-shell">
-        <div class="zr-section-heading">
-          <div>
-            <span class="zr-eyebrow">Local roots. Professional standards.</span>
-            <h2 id="roots-title">Built here. Accountable here.</h2>
-          </div>
-          <p>Zenith was built in Escondido by people who understand Southern California roofs, weather, neighborhoods, and the trust it takes to work on someone’s home.</p>
-        </div>
-        <div class="zr-roots-grid">
-          <article>
-            <span class="zr-card-number">01</span>
-            <h3>San Diego roots</h3>
-            <p>Born and raised in San Diego County, our owner built the company in Escondido and has lived here all his life. We know the microclimates, winds, and conditions local roofs face.</p>
-          </article>
-          <article>
-            <span class="zr-card-number">02</span>
-            <h3>Hands-on leadership</h3>
-            <p>We learned the craft by doing the work. That field experience shapes how our team plans details, communicates clearly, and keeps every project moving smoothly.</p>
-          </article>
-          <article>
-            <span class="zr-card-number">03</span>
-            <h3>Faith &amp; family</h3>
-            <p>We are a family that loves God and strives to be worthy of trust. Doing the right thing—even when no one is watching—is part of how we run the company.</p>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section class="zr-section zr-about-standard">
-      <div class="zr-shell zr-standard-grid">
-        <div class="zr-standard-copy">
-          <span class="zr-eyebrow zr-eyebrow--light">The Zenith standard</span>
-          <h2>Work you can see. Details you can trust.</h2>
-          <p>A great roof is more than shingles or tile. It is correct flashing, watertight transitions, clean lines, manufacturer-approved installation, and the confidence of knowing what happened at every stage.</p>
-          <ul>
-            <li><span>✓</span><div><b>Clear recommendations</b><small>Practical options explained without pressure.</small></div></li>
-            <li><span>✓</span><div><b>Real photo documentation</b><small>Before, during, and after photos of the work.</small></div></li>
-            <li><span>✓</span><div><b>Protected, clean jobsites</b><small>Daily cleanup and respect for your property.</small></div></li>
-            <li><span>✓</span><div><b>One capable local team</b><small>Repairs, replacements, tile, flat roofing, gutters, skylights, and more.</small></div></li>
-          </ul>
-          <a class="zr-text-link" href="/projects/">See real Zenith roofing projects <span aria-hidden="true">→</span></a>
-        </div>
-        <a class="zr-standard-photo" href="/projects/" aria-label="View completed Zenith roofing projects">
-          <img src="/images/modern-tile-roof-1280.webp" width="1280" height="853" alt="Completed modern tile roof by Zenith Roofing Services" loading="lazy">
-          <span><small>Real project photography</small><b>Built for Southern California</b></span>
-        </a>
-      </div>
-    </section>
-
-    <section class="zr-section zr-about-service-area" aria-labelledby="area-title">
-      <div class="zr-shell zr-area-card">
-        <div>
-          <span class="zr-eyebrow">Proudly serving Southern California</span>
-          <h2 id="area-title">Local roofing expertise, from San Diego to Temecula.</h2>
-        </div>
-        <div class="zr-area-list" aria-label="Primary service areas">
-          <span>Escondido</span><span>North County</span><span>San Diego</span><span>Temecula</span><span>Murrieta</span><span>Menifee</span>
-        </div>
-        <div class="zr-area-actions">
-          <a class="zr-button zr-button--orange" href="/contact/">Request an Estimate <span aria-hidden="true">→</span></a>
-          <a class="zr-button zr-button--outline" href="/services/">Explore Services</a>
         </div>
       </div>
     </section>

--- a/components/footer.html
+++ b/components/footer.html
@@ -1,142 +1,56 @@
-<footer id="site-footer" class="ftr" role="contentinfo">
-  <!-- Top CTA strip -->
-  <div class="ftr-cta">
-    <div class="ftr-container">
-      <p class="ftr-cta-text">Need help with your roof in San Diego or Temecula?</p>
-      <div class="ftr-cta-actions">
-        <a class="ftr-btn ftr-btn-primary" href="tel:8589006163" aria-label="Call Zenith Roofing Services at 858-900-6163">Call 858-900-6163</a>
-        <a aria-label="Go to Home — Get a Free Estimate" class="ftr-btn ftr-btn-ghost" href="/">Get a Free Estimate</a>
+<footer class="site-footer" role="contentinfo">
+  <div class="shell">
+    <div class="footer-cta">
+      <div>
+        <span class="eyebrow eyebrow--light">A better roof starts here</span>
+        <h2>Clear answers. Quality work. No pressure.</h2>
+      </div>
+      <div class="footer-cta__actions">
+        <a class="button button--orange" href="/contact/">Request a Free Estimate</a>
+        <a class="button button--ghost-light" href="tel:8589006163">Call 858-900-6163</a>
+      </div>
+    </div>
+
+    <div class="footer-grid">
+      <div class="footer-brand">
+        <a class="brand brand--footer" href="/" aria-label="Zenith Roofing Services home">
+          <img class="brand__logo" src="/images/zenith-roofing-shirt-logo-original.png" alt="Zenith Roofing Services" width="1254" height="1254" loading="lazy" decoding="async">
+        </a>
+        <p>Licensed Southern California roofing specialists serving homes, HOAs, property managers, and businesses with documented, dependable craftsmanship.</p>
+        <div class="footer-proof">CSLB #1036112 • C-39<br>Licensed &amp; insured</div>
+      </div>
+      <div>
+        <h3>Services</h3>
+        <a href="/services/roof-repairs/">Roof Repair</a>
+        <a href="/services/roof-replacement/">Roof Replacement</a>
+        <a href="/services/residential/tile-lift-lay/">Tile Roofing</a>
+        <a href="/services/commercial/tpo/">Commercial &amp; TPO</a>
+        <a href="/services/gutters/">Gutters</a>
+      </div>
+      <div>
+        <h3>Company</h3>
+        <a href="/about/">About Zenith</a>
+        <a href="/projects/">Real Projects</a>
+        <a href="/reviews/">Customer Reviews</a>
+        <a href="/financing/">Financing</a>
+        <a href="/service-areas/">Service Areas</a>
+      </div>
+      <div>
+        <h3>Contact</h3>
+        <a href="tel:8589006163">858-900-6163</a>
+        <a href="sms:+18589006163">Text our team</a>
+        <a href="mailto:info@zenithroofingservices.com">info@zenithroofingservices.com</a>
+        <p>Escondido • San Diego • Temecula</p>
+      </div>
+    </div>
+
+    <div class="footer-bottom">
+      <span>© 2026 Zenith Roofing Services, Inc.</span>
+      <div>
+        <a href="/privacy.html">Privacy</a>
+        <a href="/terms.html">Terms</a>
+        <a href="/sitemap.xml">Sitemap</a>
       </div>
     </div>
   </div>
-
-  <!-- Main footer -->
-  <div class="ftr-main">
-    <div class="ftr-container ftr-grid">
-      <!-- Brand / About -->
-      <section class="ftr-col ftr-brand" aria-labelledby="ftr-brand-title">
-        <h2 id="ftr-brand-title" class="sr-only">About Zenith Roofing Services</h2>
-
-        <a href="/" class="ftr-logo" aria-label="Zenith Roofing Services home">
-          <img src="/images/zenith-roofing-shirt-logo-original.png" alt="Zenith Roofing Services" width="1254" height="1254" loading="lazy" decoding="async" />
-        </a>
-
-        <div class="ftr-wordmark">
-          <span class="ftr-name">Zenith Roofing Services, Inc.</span>
-          <span class="ftr-lic">CSLB #1036112 (C-39)</span>
-        </div>
-
-        <p class="ftr-blurb">
-          Trusted roof repair & replacement for homes, HOAs, and businesses.
-          Serving North County San Diego &amp; Temecula with photo documentation,
-          clean job sites, and dependable warranties.
-        </p>
-
-        <ul class="ftr-contact">
-          <li><a href="tel:8589006163" aria-label="Call 858-900-6163">📞 858-900-6163</a></li>
-          <li><a href="#estimate">✉️ Request an Estimate</a></li>
-        </ul>
-
-        <!-- Social -->
-        <div class="ftr-social" aria-label="Social media">
-          <a class="ftr-social-btn" href="https://www.instagram.com/zenithroofingservices_ca/?hl=en"
-             target="_blank" rel="noopener nofollow" aria-label="Follow on Instagram">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7zm5 3.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11zm0 2a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7zm5.8-.9a1.1 1.1 0 1 1 0 2.2 1.1 1.1 0 0 1 0-2.2z"/>
-            </svg>
-            <span class="sr-only">Instagram</span>
-          </a>
-
-          <a class="ftr-social-btn" href="https://www.facebook.com/zenithroofingservicesca/"
-             target="_blank" rel="noopener nofollow" aria-label="Follow on Facebook">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M22 12.07C22 6.48 17.52 2 11.93 2 6.35 2 1.86 6.48 1.86 12.07c0 4.99 3.64 9.13 8.39 9.93v-7.02H7.9v-2.9h2.35v-2.2c0-2.32 1.38-3.61 3.5-3.61.99 0 2.03.18 2.03.18v2.24h-1.14c-1.12 0-1.47.69-1.47 1.39v2h2.5l-.4 2.9h-2.1V22c4.75-.8 8.39-4.94 8.39-9.93z"/>
-            </svg>
-            <span class="sr-only">Facebook</span>
-          </a>
-        </div>
-
-        <!-- Badges / directories -->
-        <ul class="ftr-profiles" aria-label="Certifications & directories">
-          <li><a href="https://www.owenscorning.com/en-us/roofing/contractors/contractor-profile/230828" target="_blank" rel="nofollow noopener">Owens Corning Preferred</a></li>
-          <li><a href="https://share.google/5hObHe0NZpdu8wbaO" target="_blank" rel="nofollow noopener">Google Guaranteed</a></li>
-          <li><a href="https://www.angi.com/companylist/us/ca/escondido/zenith-roofing-services-inc-reviews-1.htm" target="_blank" rel="nofollow noopener">Angi</a></li>
-          <li><a href="https://www.yelp.com/biz/zenith-roofing-services-escondido" target="_blank" rel="nofollow noopener">Yelp</a></li>
-          <li><a href="https://www.guildquality.com/pro/zenith-roofing-services" target="_blank" rel="nofollow noopener">GuildQuality</a></li>
-          <li><a href="https://directorii.com/us/ca/escondido/zenith-roofing-services-reviews-191/?country=us&state=ca&city=fallbrook&category=roofing" target="_blank" rel="nofollow noopener">Directorii</a></li>
-        </ul>
-      </section>
-
-      <!-- Quick Links (accordion on mobile) -->
-      <nav class="ftr-col" aria-labelledby="ftr-links-title">
-        <details class="ftr-acc" open>
-          <summary id="ftr-links-title" class="ftr-title">Quick Links</summary>
-          <ul class="ftr-list">
-            <li><a href="/">Home</a></li>
-            <li><a href="/projects/">Projects</a></li>
-            <li><a href="/reviews/">Reviews</a></li>
-            <li><a href="/about/">About</a></li>
-            <li><a href="/financing/">Roof Financing</a></li>
-            <li><a href="/contact/">Contact</a></li>
-            <li><a href="/blog/">Blog</a></li>
-            <li><a href="/glossary/">Glossary</a></li>
-          </ul>
-        </details>
-      </nav>
-
-      <!-- Services (accordion on mobile) -->
-      <nav class="ftr-col" aria-labelledby="ftr-services-title">
-        <details class="ftr-acc" open>
-          <summary id="ftr-services-title" class="ftr-title">Services</summary>
-          <ul class="ftr-list">
-            <li><a href="https://zenithroofingservices.com/services/roof-replacement/">Shingle Roof Replacement</a></li>
-            <li><a href="https://zenithroofingservices.com/services/residential/tile-lift-lay/">Tile Lift &amp; Lay</a></li>
-            <li><a href="https://zenithroofingservices.com/services/residential/leak-repair-troubleshooting/">Leak Repair &amp; Maintenance</a></li>
-            <li><a href="/services/residential/tpo/">TPO Single-Ply</a></li>
-            <li><a href="https://zenithroofingservices.com/services/residential/torch-down/">Torch-Down</a></li>
-            <li><a href="/services/residential/silicone/">Silicone / Cool Roof Coatings</a></li>
-            <li><a href="https://zenithroofingservices.com/services/gutters/">Seamless Gutters</a></li>
-            <li><a href="https://zenithroofingservices.com/services/real-estate/roof-certifications/">Roof Certifications (Real Estate)</a></li>
-          </ul>
-        </details>
-      </nav>
-
-      <!-- Service Areas (accordion on mobile) -->
-      <nav class="ftr-col" aria-labelledby="ftr-areas-title">
-        <details class="ftr-acc" open>
-          <summary id="ftr-areas-title" class="ftr-title">Service Areas</summary>
-          <ul class="ftr-list ftr-columns">
-            <li><a href="/service-areas/escondido/">Escondido</a></li>
-            <li><a href="/service-areas/temecula/">Temecula</a></li>
-            <li><a href="/service-areas/san-marcos/">San Marcos</a></li>
-            <li><a href="/service-areas/vista/">Vista</a></li>
-            <li><a href="/service-areas/carlsbad/">Carlsbad</a></li>
-            <li><a href="/service-areas/oceanside/">Oceanside</a></li>
-            <li><a href="/service-areas/poway/">Poway</a></li>
-            <li><a href="/service-areas/rancho-bernardo/">Rancho&nbsp;Bernardo</a></li>
-            <li><a href="/service-areas/fallbrook/">Fallbrook</a></li>
-            <li><a href="/service-areas/murrieta/">Murrieta</a></li>
-            <li><a href="/service-areas/menifee/">Menifee</a></li>
-          </ul>
-        </details>
-      </nav>
-    </div>
-  </div>
-
-  <!-- Bottom bar -->
-  <div class="ftr-bottom">
-    <div class="ftr-container ftr-bottom-row">
-      <p class="ftr-copy">© 2026 Zenith Roofing Services, Inc. All rights reserved.</p>
-      <ul class="ftr-legal">
-        <li><span>CSLB #1036112 (C-39)</span></li>
-        <li><a href="/privacy.html">Privacy</a></li>
-        <li><a href="/terms.html">Terms</a></li>
-        <li><a href="/sitemap.xml">Sitemap</a></li>
-      </ul>
-      <a class="ftr-top" href="#top" aria-label="Back to top">↑ Top</a>
-    </div>
-  </div>
-
-  <!-- JSON-LD stays the same as before -->
-  <script src="/js/footer.js" defer></script>
 </footer>

--- a/components/header-section.html
+++ b/components/header-section.html
@@ -18,7 +18,6 @@
 
     <a href="/" class="logo-section logo-link" aria-label="Zenith Roofing Services home">
       <img src="/images/zenith-roofing-shirt-logo-original.png" width="1254" height="1254" alt="Zenith Roofing Services" class="logo" decoding="async" fetchpriority="high">
-      <span class="license">Lic# 1036112</span>
     </a>
 
     <nav class="nav-bar" aria-label="Primary navigation">

--- a/components/header-section.html
+++ b/components/header-section.html
@@ -1,121 +1,123 @@
-<div class="zr-trust-ribbon" role="note" aria-label="Zenith Roofing credentials">
-  <div class="zr-trust-ribbon__inner">
+<a class="skip-link" href="#main-content">Skip to main content</a>
+
+<div class="trust-ribbon">
+  <div class="shell trust-ribbon__inner">
     <span>California Licensed C-39 • CSLB #1036112</span>
-    <span class="zr-trust-ribbon__desktop">Owens Corning Preferred Contractor</span>
-    <a href="/reviews/"><strong>★ 194</strong> customer reviews across trusted platforms</a>
+    <span class="trust-ribbon__desktop">Owens Corning Preferred Contractor</span>
+    <a href="/reviews/"><b>★ 194</b> customer reviews across trusted platforms</a>
   </div>
 </div>
 
-<header class="header">
-  <div class="header-inner">
-    <div class="mobile-header">
-      <button class="menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false">☰</button>
-      <a href="/" class="logo-section logo-link" aria-label="Zenith Roofing Services home">
-        <img src="/images/zenith-roofing-shirt-logo-original.png" width="1254" height="1254" alt="Zenith Roofing Services" class="logo" decoding="async" fetchpriority="high">
-      </a>
-      <a href="tel:8589006163" class="mobile-call" aria-label="Call 858-900-6163">Call</a>
-    </div>
-
-    <a href="/" class="logo-section logo-link" aria-label="Zenith Roofing Services home">
-      <img src="/images/zenith-roofing-shirt-logo-original.png" width="1254" height="1254" alt="Zenith Roofing Services" class="logo" decoding="async" fetchpriority="high">
+<header class="site-header">
+  <div class="shell site-header__inner">
+    <a class="brand" href="/" aria-label="Zenith Roofing Services home">
+      <img class="brand__logo" src="/images/zenith-roofing-shirt-logo-original.png" alt="Zenith Roofing Services" width="1254" height="1254" decoding="async" fetchpriority="high">
     </a>
 
-    <nav class="nav-bar" aria-label="Primary navigation">
-      <ul class="nav-links">
-        <li><a href="/">Home</a></li>
-        <li><a href="/projects/">Projects</a></li>
-        <li class="dropdown">
-          <a href="/services/">Services</a>
-          <div class="dropdown-menu zr-mega-menu">
-            <div class="zr-mega-menu__group">
-              <span class="zr-nav-label">Repair &amp; Maintenance</span>
-              <a href="/services/roof-repairs/">Roof Repairs</a>
-              <a href="/services/roof-repairs/roof-tune-up/">Roof Tune-Up</a>
-              <a href="/services/roof-repairs/tile-roof-repair/">Tile Roof Repair</a>
-              <a href="/services/roof-repairs/clay-tile-roof-repair/">Clay Tile Repair</a>
-              <a href="/services/roof-repairs/skylight-repair/">Skylight Repair</a>
-              <a href="/services/roof-inspection/">Roof Inspections</a>
-            </div>
-            <div class="zr-mega-menu__group">
-              <span class="zr-nav-label">Roofing Systems</span>
-              <a href="/services/roof-replacement/">Roof Replacement</a>
-              <a href="/services/residential/tile-lift-lay/">Tile Lift &amp; Reset</a>
-              <a href="/services/residential/asphalt-shingles/">Asphalt Shingles</a>
-              <a href="/services/commercial/tpo/">TPO Roofing</a>
-              <a href="/services/commercial/torch-down/">Torch-Down Roofing</a>
-              <a href="/services/commercial/silicone-coatings/">Silicone Coatings</a>
-            </div>
-            <div class="zr-mega-menu__group zr-mega-menu__feature">
-              <span class="zr-nav-label">Property Services</span>
-              <a href="/services/commercial/">Commercial Roofing</a>
-              <a href="/services/insurance-claims/">Insurance &amp; Storm Claims</a>
-              <a href="/services/real-estate/">Real Estate Roofing</a>
-              <a href="/services/gutters/">Seamless Gutters</a>
-              <p>Not sure what your roof needs? Start with a clear, photo-documented inspection.</p>
-              <a class="zr-mega-cta" href="/contact/">Request an inspection →</a>
-            </div>
+    <nav class="desktop-nav" aria-label="Primary navigation">
+      <a href="/">Home</a>
+      <div class="nav-mega">
+        <a class="nav-mega__trigger" href="/services/">Services <span aria-hidden="true">⌄</span></a>
+        <div class="nav-mega__panel">
+          <div>
+            <span class="nav-eyebrow">Repair &amp; Maintenance</span>
+            <a href="/services/roof-repairs/">Roof Repairs <span>→</span></a>
+            <a href="/services/roof-repairs/roof-tune-up/">Roof Tune-Up <span>→</span></a>
+            <a href="/services/roof-repairs/tile-roof-repair/">Tile Roof Repair <span>→</span></a>
+            <a href="/services/roof-repairs/clay-tile-roof-repair/">Clay Tile Repair <span>→</span></a>
+            <a href="/services/roof-repairs/skylight-repair/">Skylight Repair <span>→</span></a>
+            <a href="/services/roof-inspection/">Roof Inspections <span>→</span></a>
           </div>
-        </li>
-        <li><a href="/reviews/">Reviews</a></li>
-        <li><a href="/about/">About</a></li>
-        <li><a href="/blog/">Blog</a></li>
-        <li><a href="/glossary/">Glossary</a></li>
-        <li><a href="/financing/">Financing</a></li>
-        <li><a href="/contact/">Contact</a></li>
-        <li><a href="/youtube/">YouTube</a></li>
-      </ul>
+          <div>
+            <span class="nav-eyebrow">Roofing Systems</span>
+            <a href="/services/roof-replacement/">Roof Replacement <span>→</span></a>
+            <a href="/services/residential/tile-lift-lay/">Tile Lift &amp; Reset <span>→</span></a>
+            <a href="/services/residential/asphalt-shingles/">Asphalt Shingles <span>→</span></a>
+            <a href="/services/commercial/tpo/">TPO Roofing <span>→</span></a>
+            <a href="/services/commercial/torch-down/">Torch-Down Roofing <span>→</span></a>
+            <a href="/services/commercial/silicone-coatings/">Silicone Coatings <span>→</span></a>
+          </div>
+          <div class="nav-mega__feature">
+            <span class="nav-eyebrow">Property Services</span>
+            <a href="/services/commercial/">Commercial Roofing <span>→</span></a>
+            <a href="/services/insurance-claims/">Insurance &amp; Storm Claims <span>→</span></a>
+            <a href="/services/real-estate/">Real Estate Roofing <span>→</span></a>
+            <a href="/services/gutters/">Seamless Gutters <span>→</span></a>
+            <p>Not sure what your roof needs? Start with a clear, photo-documented inspection.</p>
+            <a class="text-link" href="/contact/">Request an inspection <span>→</span></a>
+          </div>
+        </div>
+      </div>
+      <a href="/projects/">Projects</a>
+      <a href="/reviews/">Reviews</a>
+      <a href="/service-areas/">Service Areas</a>
+      <a href="/financing/">Financing</a>
+      <a href="/about/">About</a>
+      <a href="/blog/">Resources</a>
     </nav>
 
-    <div class="phone-section">
-      <p>Call or text</p>
-      <a href="tel:8589006163">858-900-6163</a>
-      <a href="/contact/" class="call-button">Free Estimate</a>
+    <div class="header-actions">
+      <a class="header-phone" href="tel:8589006163">
+        <small>Call or text</small>
+        <b>858-900-6163</b>
+      </a>
+      <a class="button button--orange button--small" href="/contact/">Free Estimate</a>
+      <button class="menu-button" type="button" aria-expanded="false" aria-controls="mobile-menu" aria-label="Open navigation">
+        <span></span><span></span><span></span>
+      </button>
     </div>
   </div>
 </header>
 
-<nav class="mobile-nav" aria-label="Mobile navigation">
-  <div class="zr-mobile-nav__head">
+<div class="drawer-backdrop" aria-hidden="true"></div>
+<aside class="mobile-drawer" id="mobile-menu" aria-hidden="true">
+  <div class="mobile-drawer__head">
     <span>Explore Zenith</span>
-    <button class="menu-toggle" type="button" aria-label="Close navigation">×</button>
+    <button class="mobile-drawer__close" type="button" aria-label="Close navigation">×</button>
   </div>
-  <ul class="mobile-links">
-    <li><a href="/">Home</a></li>
-    <li><a href="/projects/">Projects</a></li>
-    <li>
-      <button class="accordion-toggle" type="button">Roofing Services <span class="chevron">›</span></button>
-      <ul class="submenu">
-        <li><a href="/services/">All Roofing Services</a></li>
-        <li><a href="/services/roof-repairs/">Roof Repairs</a></li>
-        <li><a href="/services/roof-replacement/">Roof Replacement</a></li>
-        <li><a href="/services/residential/tile-lift-lay/">Tile Lift &amp; Reset</a></li>
-        <li><a href="/services/residential/asphalt-shingles/">Asphalt Shingles</a></li>
-        <li><a href="/services/commercial/tpo/">TPO Roofing</a></li>
-        <li><a href="/services/commercial/torch-down/">Torch-Down Roofing</a></li>
-        <li><a href="/services/commercial/silicone-coatings/">Silicone Coatings</a></li>
-        <li><a href="/services/gutters/">Seamless Gutters</a></li>
-        <li><a href="/services/roof-inspection/">Roof Inspections</a></li>
-        <li><a href="/services/insurance-claims/">Insurance &amp; Storm Claims</a></li>
-        <li><a href="/services/real-estate/">Real Estate Roofing</a></li>
-      </ul>
-    </li>
-    <li><a href="/reviews/">Reviews</a></li>
-    <li><a href="/about/">About</a></li>
-    <li><a href="/blog/">Blog</a></li>
-    <li><a href="/glossary/">Glossary</a></li>
-    <li><a href="/financing/">Financing</a></li>
-    <li><a href="/contact/">Contact</a></li>
-    <li><a href="/youtube/">YouTube</a></li>
-  </ul>
-  <div class="zr-mobile-nav__foot">
-    <span>Licensed • Insured • Locally operated</span>
-    <a href="tel:8589006163">Call 858-900-6163</a>
+  <div class="mobile-drawer__body">
+    <a href="/">Home <span>→</span></a>
+    <details open>
+      <summary>Roofing Services</summary>
+      <div class="mobile-drawer__sub">
+        <a href="/services/">All Roofing Services</a>
+        <a href="/services/roof-repairs/">Roof Repairs</a>
+        <a href="/services/roof-replacement/">Roof Replacement</a>
+        <a href="/services/roof-repairs/roof-tune-up/">Roof Tune-Up</a>
+        <a href="/services/roof-repairs/tile-roof-repair/">Tile Roof Repair</a>
+        <a href="/services/roof-repairs/clay-tile-roof-repair/">Clay Tile Repair</a>
+        <a href="/services/roof-repairs/skylight-repair/">Skylight Repair</a>
+        <a href="/services/residential/tile-lift-lay/">Tile Lift &amp; Reset</a>
+        <a href="/services/commercial/tpo/">TPO Roofing</a>
+        <a href="/services/commercial/torch-down/">Torch-Down</a>
+        <a href="/services/commercial/silicone-coatings/">Silicone Coatings</a>
+        <a href="/services/gutters/">Seamless Gutters</a>
+      </div>
+    </details>
+    <a href="/projects/">Projects <span>→</span></a>
+    <a href="/reviews/">Reviews <span>→</span></a>
+    <a href="/service-areas/">Service Areas <span>→</span></a>
+    <a href="/financing/">Financing <span>→</span></a>
+    <a href="/about/">About <span>→</span></a>
+    <details>
+      <summary>Roofing Resources</summary>
+      <div class="mobile-drawer__sub">
+        <a href="/blog/">Roofing Blog</a>
+        <a href="/glossary/">Roofing Glossary</a>
+        <a href="/youtube/">Roofing Videos</a>
+      </div>
+    </details>
+    <a href="/contact/">Contact <span>→</span></a>
   </div>
-</nav>
+  <div class="mobile-drawer__foot">
+    <p>Licensed • Insured • Locally operated</p>
+    <a class="button button--orange" href="tel:8589006163">Call 858-900-6163</a>
+  </div>
+</aside>
 
-<nav class="zr-mobile-dock" aria-label="Quick actions">
+<nav class="mobile-dock" aria-label="Quick actions">
   <a href="tel:8589006163"><span aria-hidden="true">☎</span>Call</a>
   <a href="sms:+18589006163"><span aria-hidden="true">✉</span>Text</a>
-  <a class="zr-mobile-dock__primary" href="/contact/"><span aria-hidden="true">＋</span>Estimate</a>
-  <button class="zr-dock-menu" type="button" aria-label="Open navigation" aria-expanded="false"><span aria-hidden="true">☰</span>Menu</button>
+  <a class="mobile-dock__primary" href="/contact/"><span aria-hidden="true">＋</span>Estimate</a>
+  <button class="mobile-dock__menu" type="button" aria-label="Open navigation" aria-expanded="false"><span aria-hidden="true">☰</span>Menu</button>
 </nav>

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -3359,6 +3359,11 @@ textarea:focus {
   display: none;
 }
 
+/* The premium quick-action dock replaces legacy page-level mobile bars. */
+.actionbar {
+  display: none !important;
+}
+
 /* Exact premium About page */
 .premium-page {
   width: 100%;

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -635,18 +635,6 @@ summary:focus-visible {
   filter: drop-shadow(0 7px 10px rgba(6, 41, 75, .15));
 }
 
-.header .license {
-  position: absolute;
-  right: 0;
-  bottom: 5px;
-  left: 0;
-  color: var(--zr-ink-500) !important;
-  font-size: .54rem !important;
-  font-weight: 750;
-  letter-spacing: .04em;
-  text-align: center;
-}
-
 .nav-bar {
   min-width: 0;
   flex: 1;

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -1477,6 +1477,15 @@ textarea:focus {
   transition: transform .4s var(--zr-ease), box-shadow .4s var(--zr-ease) !important;
 }
 
+.page.revs .hero .kpi,
+.page.revs .hero .kpi strong {
+  color: var(--zr-navy-950) !important;
+}
+
+.page.revs .hero .kpi > div {
+  color: var(--zr-ink-500) !important;
+}
+
 .page.revs .kpi:hover,
 .page.revs .cta:hover,
 .page.revs .review:hover {

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -2026,3 +2026,5 @@ textarea:focus {
     transition-duration: .01ms !important;
   }
 }
+
+/* End Zenith Premium System */

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -2037,6 +2037,11 @@ textarea:focus {
   margin: 0;
   overflow: hidden;
   background: var(--zr-white);
+  text-align: left;
+}
+
+.zr-about-page section {
+  text-align: left;
 }
 
 .zr-shell {

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -2917,4 +2917,1249 @@ textarea:focus {
   }
 }
 
+/* ======================================================================
+   EXACT PREMIUM SITE PORT
+   Component structure and measurements mirror zenith-roofing-premium.
+   ====================================================================== */
+
+:root {
+  --navy-950: var(--zr-navy-950);
+  --navy-900: var(--zr-navy-900);
+  --navy-850: var(--zr-navy-850);
+  --navy-800: var(--zr-navy-800);
+  --navy-700: var(--zr-navy-700);
+  --blue-500: var(--zr-blue-500);
+  --orange-600: var(--zr-orange-600);
+  --orange-500: var(--zr-orange-500);
+  --orange-400: var(--zr-orange-400);
+  --orange-100: var(--zr-orange-100);
+  --ink-950: var(--zr-ink-950);
+  --ink-700: var(--zr-ink-700);
+  --ink-500: var(--zr-ink-500);
+  --line: var(--zr-line);
+  --mist: var(--zr-mist);
+  --white: var(--zr-white);
+  --shadow-sm: var(--zr-shadow-sm);
+  --shadow-md: var(--zr-shadow-md);
+  --shadow-lg: var(--zr-shadow-lg);
+  --radius-sm: var(--zr-radius-sm);
+  --radius-md: var(--zr-radius-md);
+  --radius-lg: var(--zr-radius-lg);
+  --ease: var(--zr-ease);
+}
+
+.shell {
+  width: min(1180px, calc(100% - 40px));
+  max-width: none;
+  margin-inline: auto;
+}
+
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 1200;
+  padding: 12px 18px;
+  color: var(--white);
+  background: var(--navy-900);
+  border-radius: 10px;
+  transform: translateY(-150%);
+  transition: transform .2s ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 16px;
+  color: var(--orange-600) !important;
+  font-size: .72rem !important;
+  font-weight: 800 !important;
+  letter-spacing: .16em !important;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.eyebrow::before {
+  width: 28px;
+  height: 2px;
+  flex: 0 0 auto;
+  content: "";
+  background: currentColor;
+  border-radius: 999px;
+}
+
+.eyebrow--light {
+  color: #ff9f43 !important;
+}
+
+.button {
+  position: relative;
+  isolation: isolate;
+  display: inline-flex;
+  min-height: 54px;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  overflow: hidden;
+  padding: 14px 23px;
+  border: 1px solid transparent;
+  border-radius: 999px !important;
+  font-size: .86rem;
+  font-weight: 800 !important;
+  letter-spacing: .01em;
+  line-height: 1;
+  text-align: center;
+  transition: transform .35s var(--ease), box-shadow .35s var(--ease), background-color .35s ease, border-color .35s ease !important;
+}
+
+.button::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  background: linear-gradient(110deg, transparent 18%, rgba(255, 255, 255, .34) 48%, transparent 72%);
+  transform: translateX(-125%);
+  transition: transform .7s var(--ease);
+}
+
+.button:hover {
+  transform: translateY(-3px);
+}
+
+.button:hover::before {
+  transform: translateX(125%);
+}
+
+.button--orange {
+  color: var(--navy-950) !important;
+  background: linear-gradient(135deg, #ffad43 0%, var(--orange-500) 48%, #f06b00 100%) !important;
+  border-color: transparent !important;
+  box-shadow: 0 12px 26px rgba(237, 106, 0, .28), inset 0 1px 0 rgba(255, 255, 255, .55) !important;
+}
+
+.button--orange:hover {
+  color: var(--navy-950) !important;
+  box-shadow: 0 18px 34px rgba(237, 106, 0, .36), inset 0 1px 0 rgba(255, 255, 255, .65) !important;
+}
+
+.button--glass {
+  color: var(--white) !important;
+  background: rgba(255, 255, 255, .09) !important;
+  border-color: rgba(255, 255, 255, .32) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .12) !important;
+  backdrop-filter: blur(12px);
+}
+
+.button--glass:hover,
+.button--ghost-light:hover {
+  color: var(--white) !important;
+  background: rgba(255, 255, 255, .16) !important;
+  border-color: rgba(255, 255, 255, .56) !important;
+}
+
+.button--ghost-light {
+  color: var(--white) !important;
+  background: transparent !important;
+  border-color: rgba(255, 255, 255, .32) !important;
+}
+
+.button--small {
+  min-height: 44px;
+  padding: 11px 18px;
+  font-size: .78rem;
+}
+
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--navy-800);
+  font-size: .84rem;
+  font-weight: 800;
+}
+
+.text-link span {
+  transition: transform .3s var(--ease);
+}
+
+.text-link:hover span {
+  transform: translateX(5px);
+}
+
+/* Exact premium header */
+.trust-ribbon {
+  position: relative;
+  z-index: 1080;
+  color: rgba(255, 255, 255, .9);
+  background: linear-gradient(90deg, rgba(255, 130, 0, .12), transparent 35%), var(--navy-950);
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
+}
+
+.trust-ribbon__inner {
+  display: flex;
+  min-height: 34px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  font-size: .7rem;
+  letter-spacing: .02em;
+}
+
+.trust-ribbon a {
+  color: inherit;
+  transition: color .25s ease;
+}
+
+.trust-ribbon a:hover {
+  color: var(--orange-400);
+}
+
+.trust-ribbon b {
+  color: #ffab42;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1070;
+  background: rgba(255, 255, 255, .9);
+  border-bottom: 1px solid rgba(6, 41, 75, .08);
+  box-shadow: 0 6px 26px rgba(3, 26, 48, .05);
+  backdrop-filter: saturate(180%) blur(18px);
+}
+
+.site-header__inner {
+  position: relative;
+  display: flex;
+  min-height: 84px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.brand {
+  position: relative;
+  display: inline-flex;
+  width: 110px;
+  height: 84px;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.brand__logo {
+  position: absolute;
+  top: -10px;
+  left: 0;
+  width: 110px;
+  height: 110px;
+  max-width: none;
+  object-fit: contain;
+  filter: drop-shadow(0 7px 10px rgba(6, 41, 75, .16));
+}
+
+.desktop-nav {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: clamp(15px, 1.45vw, 26px);
+}
+
+.desktop-nav > a,
+.nav-mega__trigger {
+  position: relative;
+  display: inline-flex;
+  min-height: 84px;
+  align-items: center;
+  gap: 5px;
+  color: var(--navy-950);
+  font-size: .78rem;
+  font-weight: 750;
+  white-space: nowrap;
+}
+
+.desktop-nav > a::after,
+.nav-mega__trigger::after {
+  position: absolute;
+  right: 50%;
+  bottom: 19px;
+  left: 50%;
+  height: 2px;
+  content: "";
+  background: var(--orange-500);
+  border-radius: 999px;
+  transition: right .3s var(--ease), left .3s var(--ease);
+}
+
+.desktop-nav > a:hover::after,
+.desktop-nav > a.is-active::after,
+.nav-mega:hover .nav-mega__trigger::after,
+.nav-mega:focus-within .nav-mega__trigger::after,
+.nav-mega.is-active .nav-mega__trigger::after {
+  right: 0;
+  left: 0;
+}
+
+.desktop-nav > a.is-active,
+.nav-mega.is-active .nav-mega__trigger {
+  color: var(--navy-700);
+}
+
+.nav-mega {
+  position: static;
+}
+
+.nav-mega__panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 50%;
+  display: grid;
+  width: min(920px, calc(100vw - 60px));
+  grid-template-columns: 1fr 1fr 1.15fr;
+  gap: 0;
+  overflow: hidden;
+  visibility: hidden;
+  background: rgba(255, 255, 255, .98);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 24px;
+  box-shadow: var(--shadow-lg);
+  opacity: 0;
+  transform: translate(-50%, -12px) scale(.985);
+  transform-origin: top center;
+  transition: opacity .25s ease, transform .35s var(--ease), visibility .25s;
+}
+
+.nav-mega__panel::before {
+  position: absolute;
+  top: -14px;
+  right: 0;
+  left: 0;
+  height: 16px;
+  content: "";
+}
+
+.nav-mega:hover .nav-mega__panel,
+.nav-mega:focus-within .nav-mega__panel {
+  visibility: visible;
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.nav-mega__panel > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 27px;
+}
+
+.nav-mega__panel > div + div {
+  border-left: 1px solid var(--line);
+}
+
+.nav-eyebrow {
+  margin-bottom: 10px;
+  color: var(--orange-600);
+  font-size: .65rem;
+  font-weight: 900;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.nav-mega__panel > div > a:not(.text-link) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 0;
+  color: var(--navy-950);
+  font-size: .79rem;
+  font-weight: 720;
+  transition: color .2s ease, transform .25s var(--ease);
+}
+
+.nav-mega__panel > div > a:hover {
+  color: var(--orange-600);
+  transform: translateX(3px);
+}
+
+.nav-mega__feature {
+  color: var(--white);
+  background: linear-gradient(145deg, rgba(34, 113, 173, .28), transparent 46%), var(--navy-950);
+}
+
+.nav-mega__feature > a:not(.text-link) {
+  color: rgba(255, 255, 255, .82) !important;
+}
+
+.nav-mega__feature p {
+  margin: 15px 0 18px;
+  color: rgba(255, 255, 255, .68);
+  font-size: .72rem;
+  line-height: 1.65;
+}
+
+.nav-mega__feature .text-link {
+  color: #ffae4d;
+}
+
+.header-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 14px;
+}
+
+.header-phone {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  line-height: 1.15;
+}
+
+.header-phone small {
+  color: var(--ink-500);
+  font-size: .59rem;
+  font-weight: 750;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.header-phone b {
+  margin-top: 4px;
+  color: var(--navy-900);
+  font-size: .82rem;
+}
+
+.menu-button {
+  display: none;
+  width: 46px;
+  height: 46px;
+  cursor: pointer;
+  background: var(--navy-950);
+  border: 0;
+  border-radius: 14px;
+  box-shadow: 0 9px 22px rgba(3, 26, 48, .2);
+}
+
+.menu-button span {
+  display: block;
+  width: 19px;
+  height: 2px;
+  margin: 4px auto;
+  background: var(--white);
+  border-radius: 999px;
+}
+
+.mobile-drawer,
+.drawer-backdrop,
+.mobile-dock {
+  display: none;
+}
+
+/* Exact premium About page */
+.premium-page {
+  width: 100%;
+  margin: 0;
+  overflow: hidden;
+  color: var(--ink-950);
+  background: var(--white);
+  text-align: left;
+}
+
+.premium-page .interior-hero {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 590px;
+  align-items: center;
+  overflow: hidden;
+  padding: 0 !important;
+  color: var(--white);
+  background: var(--navy-950);
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  text-align: left;
+}
+
+.premium-page .interior-hero > img,
+.premium-page .interior-hero__shade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.premium-page .interior-hero > img {
+  object-fit: cover;
+  animation: exact-hero-settle 1.5s var(--ease) both;
+}
+
+.premium-page .interior-hero__shade {
+  z-index: 1;
+  background: linear-gradient(90deg, rgba(3, 20, 38, .97) 0%, rgba(3, 26, 48, .85) 48%, rgba(3, 26, 48, .44) 76%, rgba(3, 26, 48, .28) 100%), linear-gradient(0deg, rgba(3, 26, 48, .5), transparent 58%);
+}
+
+.premium-page .interior-hero__shade::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: radial-gradient(circle at 12% 22%, rgba(36, 126, 190, .25), transparent 30%), linear-gradient(115deg, transparent 0 64%, rgba(255, 130, 0, .07) 64% 65%, transparent 65%);
+}
+
+.premium-page .interior-hero__content {
+  position: relative;
+  z-index: 3;
+  padding-top: 88px;
+  padding-bottom: 92px;
+  animation: exact-rise-in .8s .08s var(--ease) both;
+}
+
+.premium-page .interior-hero__content h1 {
+  max-width: 850px;
+  margin: 0;
+  color: var(--white);
+  font-size: clamp(3.6rem, 6.2vw, 6.2rem) !important;
+  font-weight: 760 !important;
+  letter-spacing: -.06em !important;
+  line-height: .98 !important;
+  text-wrap: balance;
+}
+
+.premium-page .interior-hero__content > p {
+  max-width: 710px;
+  margin: 25px 0 0;
+  color: rgba(255, 255, 255, .78) !important;
+  font-size: 1.03rem;
+  line-height: 1.75;
+}
+
+.premium-page .interior-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.premium-page .interior-trust {
+  position: relative;
+  z-index: 5;
+  background: rgba(255, 255, 255, .98);
+  border-bottom: 1px solid rgba(6, 41, 75, .1);
+  box-shadow: 0 14px 38px rgba(3, 26, 48, .06);
+}
+
+.premium-page .interior-trust__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.premium-page .interior-trust__grid > span {
+  position: relative;
+  display: flex;
+  min-height: 92px;
+  flex-direction: column;
+  justify-content: center;
+  padding: 18px 30px 18px 48px;
+}
+
+.premium-page .interior-trust__grid > span::before {
+  position: absolute;
+  top: 50%;
+  left: 18px;
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  color: var(--navy-950);
+  content: "✓";
+  background: linear-gradient(135deg, #ffb24e, var(--orange-500));
+  border-radius: 7px;
+  box-shadow: 0 6px 14px rgba(237, 106, 0, .2);
+  font-size: .65rem;
+  font-weight: 950;
+  transform: translateY(-50%);
+}
+
+.premium-page .interior-trust__grid > span + span {
+  border-left: 1px solid rgba(6, 41, 75, .1);
+}
+
+.premium-page .interior-trust__grid b {
+  color: var(--navy-950);
+  font-size: .74rem;
+  letter-spacing: -.01em;
+}
+
+.premium-page .interior-trust__grid small {
+  margin-top: 4px;
+  color: var(--ink-500);
+  font-size: .62rem;
+  line-height: 1.35;
+}
+
+.premium-page .section {
+  position: relative;
+  margin: 0 !important;
+  padding: 112px 0 !important;
+  background: var(--white) !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  text-align: left;
+}
+
+.premium-page .proof-layout {
+  display: grid;
+  grid-template-columns: minmax(0, .92fr) minmax(0, 1fr);
+  align-items: center;
+  gap: clamp(55px, 8vw, 110px);
+}
+
+.premium-page .proof-copy h2 {
+  margin: 0 0 23px;
+  color: var(--navy-950);
+  font-size: clamp(2.35rem, 4vw, 4.05rem) !important;
+  font-weight: 760 !important;
+  letter-spacing: -.05em !important;
+  line-height: 1.04 !important;
+  text-wrap: balance;
+}
+
+.premium-page .proof-copy > p {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: .96rem;
+  line-height: 1.8;
+}
+
+.premium-page .about-layout .proof-copy > p + p {
+  margin-top: 15px;
+}
+
+.premium-page .about-values {
+  display: grid;
+  gap: 1px;
+  margin-top: 32px;
+  overflow: hidden;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+}
+
+.premium-page .about-values span {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  color: var(--ink-500);
+  background: var(--white);
+  font-size: .74rem;
+  line-height: 1.55;
+}
+
+.premium-page .about-values b {
+  margin-bottom: 3px;
+  color: var(--navy-950);
+  font-size: .85rem;
+}
+
+.premium-page .proof-visual {
+  position: relative;
+  padding: 0 42px 48px 0;
+}
+
+.premium-page .proof-visual::before {
+  position: absolute;
+  top: 34px;
+  right: 0;
+  bottom: 0;
+  left: 44px;
+  content: "";
+  background: linear-gradient(145deg, rgba(30, 112, 170, .2), transparent 54%), var(--navy-950);
+  border-radius: var(--radius-lg);
+}
+
+.premium-page .proof-visual > img {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  aspect-ratio: 4 / 4.1;
+  object-fit: cover;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+
+.premium-page .proof-visual__card {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  width: 270px;
+  flex-direction: column;
+  padding: 24px;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--orange-500), var(--orange-600));
+  border: 7px solid var(--white);
+  border-radius: 22px;
+  box-shadow: var(--shadow-md);
+}
+
+.premium-page .proof-visual__card strong {
+  font-size: 1.05rem;
+}
+
+.premium-page .proof-visual__card span {
+  margin-top: 4px;
+  color: rgba(3, 26, 48, .78);
+  font-size: .72rem;
+  line-height: 1.5;
+}
+
+/* Exact premium footer */
+.site-footer {
+  overflow: hidden;
+  color: rgba(255, 255, 255, .7);
+  background: radial-gradient(circle at 12% 0%, rgba(34, 118, 180, .26), transparent 25%), var(--navy-950);
+  text-align: left;
+}
+
+.site-footer .footer-cta {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 45px;
+  padding: 64px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, .12);
+}
+
+.site-footer .footer-cta h2 {
+  max-width: 690px;
+  margin: 0;
+  color: var(--white) !important;
+  font-size: clamp(2.25rem, 4vw, 3.7rem) !important;
+  font-weight: 760 !important;
+  letter-spacing: -.05em !important;
+  line-height: 1.04 !important;
+}
+
+.site-footer .footer-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 11px;
+}
+
+.site-footer .footer-grid {
+  display: grid;
+  grid-template-columns: 1.55fr repeat(3, .72fr);
+  gap: 58px;
+  padding: 66px 0 56px;
+}
+
+.site-footer .brand--footer {
+  width: 160px;
+  height: 122px;
+}
+
+.site-footer .brand--footer .brand__logo {
+  top: -15px;
+  width: 160px;
+  height: 160px;
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, .24));
+}
+
+.site-footer .footer-brand > p {
+  max-width: 370px;
+  margin: 22px 0;
+  color: rgba(255, 255, 255, .7);
+  font-size: .78rem;
+  line-height: 1.7;
+}
+
+.site-footer .footer-proof {
+  color: rgba(255, 255, 255, .52);
+  font-size: .69rem;
+  line-height: 1.65;
+}
+
+.site-footer .footer-grid > div:not(.footer-brand) {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.site-footer .footer-grid h3 {
+  margin: 8px 0 10px;
+  color: var(--white);
+  font-size: .76rem;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.site-footer .footer-grid a,
+.site-footer .footer-grid > div:not(.footer-brand) p {
+  margin: 0;
+  color: rgba(255, 255, 255, .64);
+  font-size: .72rem;
+  line-height: 1.5;
+  transition: color .2s ease, transform .25s var(--ease);
+}
+
+.site-footer .footer-grid a:hover {
+  color: var(--orange-400);
+  transform: translateX(3px);
+}
+
+.site-footer .footer-bottom {
+  display: flex;
+  min-height: 70px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 25px;
+  border-top: 1px solid rgba(255, 255, 255, .1);
+  color: rgba(255, 255, 255, .4);
+  font-size: .65rem;
+}
+
+.site-footer .footer-bottom > div {
+  display: flex;
+  gap: 22px;
+}
+
+.site-footer .footer-bottom a:hover {
+  color: var(--orange-400);
+}
+
+@keyframes exact-hero-settle {
+  from { opacity: .62; transform: scale(1.04); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes exact-rise-in {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 1120px) {
+  .desktop-nav {
+    gap: 15px;
+  }
+
+  .desktop-nav > a,
+  .nav-mega__trigger {
+    font-size: .72rem;
+  }
+
+  .header-phone {
+    display: none;
+  }
+}
+
+@media (max-width: 960px) {
+  html {
+    scroll-padding-top: 84px;
+  }
+
+  .trust-ribbon__desktop,
+  .desktop-nav,
+  .header-actions > .button {
+    display: none;
+  }
+
+  .menu-button {
+    display: block;
+  }
+
+  .site-header__inner {
+    min-height: 72px;
+  }
+
+  .brand {
+    width: 98px;
+    height: 72px;
+  }
+
+  .brand__logo {
+    top: -9px;
+    width: 98px;
+    height: 98px;
+  }
+
+  .drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1085;
+    display: block;
+    visibility: hidden;
+    background: rgba(2, 14, 28, .62);
+    opacity: 0;
+    backdrop-filter: blur(5px);
+    transition: opacity .3s ease, visibility .3s;
+  }
+
+  .drawer-backdrop.is-open {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  .mobile-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1090;
+    display: flex;
+    width: min(440px, calc(100% - 28px));
+    height: 100dvh;
+    flex-direction: column;
+    visibility: hidden;
+    color: var(--navy-950);
+    background: var(--white);
+    box-shadow: -20px 0 70px rgba(3, 26, 48, .3);
+    opacity: 0;
+    transform: translateX(104%);
+    transition: transform .42s var(--ease), opacity .3s ease, visibility .42s;
+  }
+
+  .mobile-drawer.is-open {
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(0);
+  }
+
+  .mobile-drawer__head {
+    display: flex;
+    min-height: 74px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 22px;
+    color: var(--white);
+    background: linear-gradient(135deg, rgba(31, 119, 183, .26), transparent 50%), var(--navy-950);
+  }
+
+  .mobile-drawer__head span {
+    font-size: .8rem;
+    font-weight: 900;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+  }
+
+  .mobile-drawer__head button {
+    width: 42px;
+    height: 42px;
+    cursor: pointer;
+    color: var(--white);
+    background: rgba(255, 255, 255, .08);
+    border: 1px solid rgba(255, 255, 255, .14);
+    border-radius: 13px;
+    font-size: 1.55rem;
+    line-height: 1;
+  }
+
+  .mobile-drawer__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 22px 24px;
+  }
+
+  .mobile-drawer__body > a,
+  .mobile-drawer summary {
+    display: flex;
+    min-height: 52px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 3px;
+    color: var(--navy-950);
+    border-bottom: 1px solid var(--line);
+    cursor: pointer;
+    font-size: .83rem;
+    font-weight: 800;
+    list-style: none;
+  }
+
+  .mobile-drawer summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .mobile-drawer summary::after {
+    color: var(--orange-600);
+    content: "+";
+    font-size: 1.1rem;
+  }
+
+  .mobile-drawer details[open] summary::after {
+    content: "−";
+  }
+
+  .mobile-drawer__sub {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    padding: 10px;
+    background: var(--mist);
+    border-radius: 0 0 14px 14px;
+  }
+
+  .mobile-drawer__sub a {
+    padding: 10px 8px;
+    color: var(--ink-700);
+    font-size: .7rem;
+    font-weight: 680;
+  }
+
+  .mobile-drawer__sub a:first-child {
+    color: var(--orange-600);
+  }
+
+  .mobile-drawer__foot {
+    padding: 20px 22px calc(22px + env(safe-area-inset-bottom));
+    background: var(--mist);
+    border-top: 1px solid var(--line);
+  }
+
+  .mobile-drawer__foot p {
+    margin: 0 0 12px;
+    color: var(--ink-500);
+    font-size: .68rem;
+    text-align: center;
+  }
+
+  .mobile-drawer__foot .button {
+    width: 100%;
+  }
+
+  .premium-page .interior-trust__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .premium-page .interior-trust__grid > span:nth-child(3) {
+    border-left: 0;
+  }
+
+  .premium-page .interior-trust__grid > span:nth-child(n + 3) {
+    border-top: 1px solid rgba(6, 41, 75, .1);
+  }
+
+  .premium-page .proof-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .premium-page .proof-visual {
+    max-width: 670px;
+  }
+
+  .site-footer .footer-cta {
+    grid-template-columns: 1fr;
+  }
+
+  .site-footer .footer-cta__actions {
+    justify-content: flex-start;
+  }
+
+  .site-footer .footer-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .site-footer .footer-brand,
+  .site-footer .footer-grid > div:last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 680px) {
+  body {
+    padding-bottom: calc(70px + env(safe-area-inset-bottom)) !important;
+  }
+
+  .shell {
+    width: min(100% - 28px, 1180px);
+  }
+
+  .trust-ribbon__inner {
+    min-height: 31px;
+    justify-content: center;
+    font-size: .58rem;
+    text-align: center;
+  }
+
+  .trust-ribbon__inner > span {
+    display: none;
+  }
+
+  .site-header__inner {
+    min-height: 66px;
+  }
+
+  .brand {
+    width: 88px;
+    height: 66px;
+  }
+
+  .brand__logo {
+    top: -8px;
+    width: 88px;
+    height: 88px;
+  }
+
+  .menu-button {
+    width: 43px;
+    height: 43px;
+  }
+
+  .premium-page .interior-hero {
+    min-height: 500px;
+  }
+
+  .premium-page .interior-hero__shade {
+    background: linear-gradient(0deg, rgba(3, 20, 38, .98) 8%, rgba(3, 26, 48, .75)), linear-gradient(90deg, rgba(3, 20, 38, .88), rgba(3, 26, 48, .35));
+  }
+
+  .premium-page .interior-hero__content {
+    padding-top: 70px;
+    padding-bottom: 76px;
+  }
+
+  .premium-page .interior-hero__content h1 {
+    font-size: clamp(2.65rem, 12vw, 3.7rem) !important;
+    line-height: 1 !important;
+  }
+
+  .premium-page .interior-hero__content > p {
+    margin-top: 19px;
+    font-size: .9rem;
+    line-height: 1.65;
+  }
+
+  .premium-page .interior-hero__actions {
+    flex-direction: column;
+    margin-top: 24px;
+  }
+
+  .premium-page .interior-hero__actions .button {
+    width: 100%;
+  }
+
+  .premium-page .interior-trust__grid > span {
+    min-height: 82px;
+    padding: 14px 10px 14px 38px;
+  }
+
+  .premium-page .interior-trust__grid > span::before {
+    left: 10px;
+    width: 19px;
+    height: 19px;
+  }
+
+  .premium-page .interior-trust__grid b {
+    font-size: .65rem;
+  }
+
+  .premium-page .interior-trust__grid small {
+    font-size: .55rem;
+  }
+
+  .premium-page .section {
+    padding: 76px 0 !important;
+  }
+
+  .premium-page .proof-copy h2,
+  .site-footer .footer-cta h2 {
+    font-size: clamp(2.15rem, 10vw, 3rem) !important;
+    line-height: 1.06 !important;
+  }
+
+  .premium-page .proof-layout {
+    gap: 55px;
+  }
+
+  .premium-page .proof-visual {
+    padding: 0 24px 38px 0;
+  }
+
+  .premium-page .proof-visual::before {
+    left: 27px;
+  }
+
+  .premium-page .proof-visual__card {
+    width: 235px;
+    padding: 18px;
+    border-width: 5px;
+  }
+
+  .premium-page .proof-copy > p {
+    font-size: .88rem;
+  }
+
+  .site-footer .footer-cta {
+    padding: 52px 0;
+  }
+
+  .site-footer .footer-cta__actions {
+    flex-direction: column;
+  }
+
+  .site-footer .footer-cta__actions .button {
+    width: 100%;
+  }
+
+  .site-footer .footer-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 38px 28px;
+    padding: 50px 0 42px;
+  }
+
+  .site-footer .footer-bottom {
+    min-height: 92px;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .mobile-dock {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1082;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    padding: 7px 8px calc(7px + env(safe-area-inset-bottom));
+    background: rgba(255, 255, 255, .95);
+    border-top: 1px solid rgba(6, 41, 75, .12);
+    box-shadow: 0 -12px 35px rgba(3, 26, 48, .14);
+    backdrop-filter: blur(16px);
+  }
+
+  .mobile-dock a,
+  .mobile-dock button {
+    display: flex;
+    min-height: 54px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    color: var(--navy-900) !important;
+    background: transparent;
+    border: 0;
+    border-radius: 12px;
+    cursor: pointer;
+    font-size: .57rem;
+    font-weight: 800;
+  }
+
+  .mobile-dock span {
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .mobile-dock .mobile-dock__primary {
+    color: var(--navy-950) !important;
+    background: linear-gradient(135deg, #ffad43, var(--orange-500));
+    box-shadow: 0 7px 18px rgba(237, 106, 0, .25);
+  }
+}
+
 /* End Zenith Premium System */

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -2027,4 +2027,889 @@ textarea:focus {
   }
 }
 
+/* ======================================================================
+   ABOUT — faithful port of the approved image-led premium reference
+   Dedicated classes keep this structure independent from legacy cards.
+   ====================================================================== */
+
+.zr-about-page {
+  width: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--zr-white);
+}
+
+.zr-shell {
+  width: min(1240px, calc(100% - 48px));
+  margin-inline: auto;
+}
+
+.zr-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  color: var(--zr-orange-600);
+  font-size: .69rem;
+  font-weight: 900;
+  letter-spacing: .15em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.zr-eyebrow::before {
+  width: 28px;
+  height: 2px;
+  flex: 0 0 auto;
+  content: "";
+  background: currentColor;
+  border-radius: 999px;
+}
+
+.zr-eyebrow--light {
+  color: #ffae4d;
+}
+
+.zr-button {
+  display: inline-flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 14px 22px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: .76rem;
+  font-weight: 850;
+  line-height: 1;
+  text-decoration: none;
+  transition: transform .35s var(--zr-ease), box-shadow .35s var(--zr-ease), background-color .25s ease, border-color .25s ease;
+}
+
+.zr-button--orange {
+  color: var(--zr-navy-950);
+  background: linear-gradient(135deg, #ffb34f, var(--zr-orange-500) 48%, var(--zr-orange-600));
+  box-shadow: 0 12px 28px rgba(237, 106, 0, .3), inset 0 1px 0 rgba(255, 255, 255, .6);
+}
+
+.zr-button--orange:hover {
+  color: var(--zr-navy-950);
+  box-shadow: 0 19px 38px rgba(237, 106, 0, .38), inset 0 1px 0 rgba(255, 255, 255, .7);
+  transform: translateY(-3px);
+}
+
+.zr-button--glass {
+  color: var(--zr-white);
+  background: rgba(255, 255, 255, .08);
+  border-color: rgba(255, 255, 255, .38);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .1);
+  backdrop-filter: blur(12px);
+}
+
+.zr-button--glass:hover {
+  color: var(--zr-white);
+  background: rgba(255, 255, 255, .16);
+  border-color: rgba(255, 255, 255, .66);
+  transform: translateY(-3px);
+}
+
+.zr-button--outline {
+  color: var(--zr-navy-950);
+  background: var(--zr-white);
+  border-color: rgba(6, 41, 75, .18);
+  box-shadow: 0 8px 24px rgba(6, 41, 75, .08);
+}
+
+.zr-button--outline:hover {
+  color: var(--zr-orange-600);
+  border-color: rgba(255, 130, 0, .48);
+  box-shadow: var(--zr-shadow-sm);
+  transform: translateY(-3px);
+}
+
+.zr-interior-hero {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 590px;
+  align-items: center;
+  overflow: hidden;
+  color: var(--zr-white);
+  background: var(--zr-navy-950);
+}
+
+.zr-interior-hero > img,
+.zr-interior-hero__shade {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.zr-interior-hero > img {
+  object-fit: cover;
+  object-position: center 58%;
+  animation: zr-hero-settle 1.5s var(--zr-ease) both;
+}
+
+.zr-interior-hero__shade {
+  z-index: 1;
+  background:
+    linear-gradient(90deg, rgba(3, 20, 38, .98) 0%, rgba(3, 26, 48, .88) 46%, rgba(3, 26, 48, .48) 76%, rgba(3, 26, 48, .3) 100%),
+    linear-gradient(0deg, rgba(3, 26, 48, .55), transparent 60%);
+}
+
+.zr-interior-hero__shade::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background:
+    radial-gradient(circle at 12% 22%, rgba(36, 126, 190, .26), transparent 30%),
+    linear-gradient(115deg, transparent 0 64%, rgba(255, 130, 0, .08) 64% 65%, transparent 65%);
+}
+
+.zr-interior-hero__content {
+  position: relative;
+  z-index: 3;
+  padding-top: 88px;
+  padding-bottom: 92px;
+  animation: zr-rise-in .8s .08s var(--zr-ease) both;
+}
+
+.zr-interior-hero__content h1 {
+  max-width: 850px;
+  margin: 0;
+  color: var(--zr-white);
+  font-size: clamp(3.6rem, 6.2vw, 6.2rem) !important;
+  font-weight: 760 !important;
+  letter-spacing: -.06em !important;
+  line-height: .98 !important;
+  text-wrap: balance;
+}
+
+.zr-interior-hero__content > p {
+  max-width: 710px;
+  margin: 25px 0 0;
+  color: rgba(255, 255, 255, .8);
+  font-size: 1.03rem;
+  line-height: 1.75;
+}
+
+.zr-interior-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.zr-interior-trust {
+  position: relative;
+  z-index: 5;
+  background: rgba(255, 255, 255, .98);
+  border-bottom: 1px solid rgba(6, 41, 75, .1);
+  box-shadow: 0 14px 38px rgba(3, 26, 48, .06);
+}
+
+.zr-interior-trust__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.zr-interior-trust__grid > span {
+  position: relative;
+  display: flex;
+  min-height: 92px;
+  flex-direction: column;
+  justify-content: center;
+  padding: 18px 26px 18px 52px;
+}
+
+.zr-interior-trust__grid > span::before {
+  position: absolute;
+  top: 50%;
+  left: 18px;
+  display: grid;
+  width: 21px;
+  height: 21px;
+  place-items: center;
+  color: var(--zr-navy-950);
+  content: "✓";
+  background: linear-gradient(135deg, #ffb24e, var(--zr-orange-500));
+  border-radius: 7px;
+  box-shadow: 0 6px 14px rgba(237, 106, 0, .22);
+  font-size: .65rem;
+  font-weight: 950;
+  transform: translateY(-50%);
+}
+
+.zr-interior-trust__grid > span + span {
+  border-left: 1px solid rgba(6, 41, 75, .1);
+}
+
+.zr-interior-trust__grid b {
+  color: var(--zr-navy-950);
+  font-size: .76rem;
+  letter-spacing: -.01em;
+}
+
+.zr-interior-trust__grid small {
+  margin-top: 4px;
+  color: var(--zr-ink-500);
+  font-size: .62rem;
+  line-height: 1.35;
+}
+
+.zr-section {
+  position: relative;
+  padding: 112px 0;
+}
+
+.zr-about-intro {
+  background:
+    radial-gradient(circle at 100% 0, rgba(255, 130, 0, .055), transparent 26%),
+    var(--zr-white);
+}
+
+.zr-about-proof {
+  display: grid;
+  grid-template-columns: minmax(0, .92fr) minmax(0, 1fr);
+  align-items: center;
+  gap: clamp(58px, 8vw, 112px);
+}
+
+.zr-about-copy h2,
+.zr-section-heading h2,
+.zr-standard-copy h2,
+.zr-area-card h2 {
+  margin: 0;
+  color: var(--zr-navy-950);
+  font-size: clamp(2.65rem, 4.8vw, 4.7rem) !important;
+  font-weight: 760 !important;
+  letter-spacing: -.055em !important;
+  line-height: 1.01 !important;
+}
+
+.zr-about-copy > p {
+  margin: 24px 0 0;
+  color: var(--zr-ink-700);
+  font-size: .97rem;
+  line-height: 1.82;
+}
+
+.zr-about-copy > p + p {
+  margin-top: 15px;
+}
+
+.zr-about-values {
+  display: grid;
+  gap: 1px;
+  margin-top: 34px;
+  overflow: hidden;
+  background: var(--zr-line);
+  border: 1px solid var(--zr-line);
+  border-radius: 18px;
+  box-shadow: 0 12px 30px rgba(6, 41, 75, .06);
+}
+
+.zr-about-values span {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  color: var(--zr-ink-500);
+  background: var(--zr-white);
+  font-size: .75rem;
+  line-height: 1.55;
+  transition: color .3s ease, background-color .3s ease, padding-left .35s var(--zr-ease);
+}
+
+.zr-about-values span:hover {
+  color: var(--zr-ink-700);
+  background: #fffaf5;
+  padding-left: 25px;
+}
+
+.zr-about-values b {
+  margin-bottom: 3px;
+  color: var(--zr-navy-950);
+  font-size: .88rem;
+}
+
+.zr-about-visual {
+  position: relative;
+  padding: 0 42px 48px 0;
+}
+
+.zr-about-visual::before {
+  position: absolute;
+  top: 34px;
+  right: 0;
+  bottom: 0;
+  left: 44px;
+  content: "";
+  background: linear-gradient(145deg, rgba(30, 112, 170, .22), transparent 54%), var(--zr-navy-950);
+  border-radius: var(--zr-radius-lg);
+}
+
+.zr-about-visual picture {
+  position: relative;
+  z-index: 1;
+  display: block;
+  overflow: hidden;
+  border-radius: var(--zr-radius-lg);
+  box-shadow: var(--zr-shadow-lg);
+}
+
+.zr-about-visual img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 4.1;
+  object-fit: cover;
+  transition: transform .8s var(--zr-ease);
+}
+
+.zr-about-visual:hover img {
+  transform: scale(1.035);
+}
+
+.zr-about-license {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  width: 270px;
+  flex-direction: column;
+  padding: 24px;
+  color: var(--zr-white);
+  background: linear-gradient(135deg, var(--zr-orange-500), var(--zr-orange-600));
+  border: 7px solid var(--zr-white);
+  border-radius: 22px;
+  box-shadow: var(--zr-shadow-md);
+  transition: transform .35s var(--zr-ease), box-shadow .35s var(--zr-ease);
+}
+
+.zr-about-visual:hover .zr-about-license {
+  box-shadow: 0 22px 52px rgba(3, 26, 48, .22);
+  transform: translateY(-5px);
+}
+
+.zr-about-license strong {
+  font-size: 1.05rem;
+}
+
+.zr-about-license span {
+  margin-top: 5px;
+  color: rgba(3, 26, 48, .78);
+  font-size: .72rem;
+  line-height: 1.5;
+}
+
+.zr-about-roots {
+  background:
+    radial-gradient(circle at 0 0, rgba(42, 131, 196, .08), transparent 26%),
+    var(--zr-mist);
+  border-block: 1px solid rgba(6, 41, 75, .07);
+}
+
+.zr-section-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(300px, .62fr);
+  align-items: end;
+  gap: 70px;
+  margin-bottom: 48px;
+}
+
+.zr-section-heading > p {
+  margin: 0;
+  color: var(--zr-ink-700);
+  font-size: .93rem;
+  line-height: 1.78;
+}
+
+.zr-roots-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 15px;
+}
+
+.zr-roots-grid article {
+  position: relative;
+  min-height: 305px;
+  padding: 34px;
+  overflow: hidden;
+  background: var(--zr-white);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 20px;
+  box-shadow: 0 10px 34px rgba(6, 41, 75, .06);
+  transition: transform .42s var(--zr-ease), box-shadow .42s var(--zr-ease), border-color .3s ease;
+}
+
+.zr-roots-grid article::after {
+  position: absolute;
+  right: -62px;
+  bottom: -92px;
+  width: 190px;
+  height: 190px;
+  content: "";
+  border: 1px solid rgba(6, 41, 75, .06);
+  border-radius: 50%;
+  box-shadow: 0 0 0 38px rgba(6, 41, 75, .018);
+}
+
+.zr-roots-grid article:hover {
+  border-color: rgba(255, 130, 0, .42);
+  box-shadow: var(--zr-shadow-md);
+  transform: translateY(-8px);
+}
+
+.zr-card-number {
+  display: inline-flex;
+  min-width: 42px;
+  min-height: 30px;
+  align-items: center;
+  justify-content: center;
+  color: var(--zr-orange-600);
+  background: var(--zr-orange-100);
+  border-radius: 999px;
+  font-size: .65rem;
+  font-weight: 900;
+  letter-spacing: .08em;
+}
+
+.zr-roots-grid h3 {
+  margin: 62px 0 0;
+  color: var(--zr-navy-950);
+  font-size: 1.35rem;
+  letter-spacing: -.035em;
+}
+
+.zr-roots-grid p {
+  margin: 15px 0 0;
+  color: var(--zr-ink-700);
+  font-size: .81rem;
+  line-height: 1.76;
+}
+
+.zr-about-standard {
+  overflow: hidden;
+  color: var(--zr-white);
+  background:
+    radial-gradient(circle at 92% 18%, rgba(42, 131, 196, .3), transparent 30%),
+    radial-gradient(circle at 3% 90%, rgba(255, 130, 0, .08), transparent 25%),
+    var(--zr-navy-950);
+}
+
+.zr-standard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, .86fr) minmax(0, 1.05fr);
+  align-items: center;
+  gap: clamp(58px, 8vw, 110px);
+}
+
+.zr-standard-copy h2 {
+  color: var(--zr-white);
+}
+
+.zr-standard-copy > p {
+  margin: 22px 0 0;
+  color: rgba(255, 255, 255, .7);
+  font-size: .94rem;
+  line-height: 1.8;
+}
+
+.zr-standard-copy ul {
+  display: grid;
+  gap: 14px;
+  margin: 30px 0 32px;
+  padding: 0;
+  list-style: none;
+}
+
+.zr-standard-copy li {
+  display: flex;
+  align-items: flex-start;
+  gap: 13px;
+}
+
+.zr-standard-copy li > span {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--zr-navy-950);
+  background: linear-gradient(135deg, #ffb24e, var(--zr-orange-500));
+  border-radius: 9px;
+  box-shadow: 0 7px 17px rgba(237, 106, 0, .24);
+  font-size: .7rem;
+  font-weight: 950;
+}
+
+.zr-standard-copy li div {
+  display: flex;
+  flex-direction: column;
+}
+
+.zr-standard-copy li b {
+  color: var(--zr-white);
+  font-size: .8rem;
+}
+
+.zr-standard-copy li small {
+  margin-top: 3px;
+  color: rgba(255, 255, 255, .55);
+  font-size: .66rem;
+  line-height: 1.5;
+}
+
+.zr-text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: #ffae4d;
+  font-size: .76rem;
+  font-weight: 850;
+}
+
+.zr-text-link span {
+  transition: transform .3s var(--zr-ease);
+}
+
+.zr-text-link:hover {
+  color: #ffc476;
+}
+
+.zr-text-link:hover span {
+  transform: translateX(5px);
+}
+
+.zr-standard-photo {
+  position: relative;
+  display: block;
+  min-height: 560px;
+  overflow: hidden;
+  border: 10px solid rgba(255, 255, 255, .08);
+  border-radius: 30px;
+  box-shadow: 0 32px 90px rgba(0, 0, 0, .3);
+}
+
+.zr-standard-photo::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(0deg, rgba(3, 20, 38, .85), transparent 52%);
+}
+
+.zr-standard-photo img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform .9s var(--zr-ease), filter .5s ease;
+}
+
+.zr-standard-photo:hover img {
+  filter: saturate(1.08) contrast(1.03);
+  transform: scale(1.045);
+}
+
+.zr-standard-photo > span {
+  position: absolute;
+  right: 30px;
+  bottom: 27px;
+  left: 30px;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+}
+
+.zr-standard-photo small {
+  color: #ffae4d;
+  font-size: .62rem;
+  font-weight: 900;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.zr-standard-photo b {
+  margin-top: 7px;
+  color: var(--zr-white);
+  font-size: 1.32rem;
+  letter-spacing: -.03em;
+}
+
+.zr-about-service-area {
+  background: var(--zr-white);
+}
+
+.zr-area-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(300px, .8fr);
+  align-items: center;
+  gap: 34px 80px;
+  padding: clamp(42px, 5vw, 70px);
+  background:
+    radial-gradient(circle at 96% 8%, rgba(42, 131, 196, .13), transparent 27%),
+    linear-gradient(145deg, #f7fafc, #eef4f8);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 30px;
+  box-shadow: var(--zr-shadow-sm);
+}
+
+.zr-area-card h2 {
+  max-width: 740px;
+  font-size: clamp(2.35rem, 4vw, 4rem) !important;
+}
+
+.zr-area-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 9px;
+}
+
+.zr-area-list span {
+  padding: 10px 14px;
+  color: var(--zr-navy-900);
+  background: rgba(255, 255, 255, .9);
+  border: 1px solid rgba(6, 41, 75, .12);
+  border-radius: 999px;
+  box-shadow: 0 5px 15px rgba(6, 41, 75, .045);
+  font-size: .67rem;
+  font-weight: 780;
+  transition: color .25s ease, border-color .25s ease, transform .3s var(--zr-ease);
+}
+
+.zr-area-list span:hover {
+  color: var(--zr-orange-600);
+  border-color: rgba(255, 130, 0, .4);
+  transform: translateY(-2px);
+}
+
+.zr-area-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+@keyframes zr-hero-settle {
+  from { opacity: .55; transform: scale(1.055); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes zr-rise-in {
+  from { opacity: 0; transform: translateY(22px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 1040px) {
+  .zr-interior-hero {
+    min-height: 540px;
+  }
+
+  .zr-interior-hero__content h1 {
+    font-size: clamp(3.2rem, 7.8vw, 5.2rem) !important;
+  }
+
+  .zr-about-proof,
+  .zr-standard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .zr-about-copy,
+  .zr-standard-copy {
+    max-width: 760px;
+  }
+
+  .zr-about-visual {
+    max-width: 690px;
+  }
+
+  .zr-standard-photo {
+    max-width: 780px;
+  }
+
+  .zr-section-heading,
+  .zr-area-card {
+    grid-template-columns: 1fr;
+    align-items: start;
+    gap: 24px;
+  }
+
+  .zr-section-heading > p {
+    max-width: 720px;
+  }
+
+  .zr-area-actions {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 760px) {
+  .zr-shell {
+    width: min(100% - 32px, 1240px);
+  }
+
+  .zr-section {
+    padding: 76px 0;
+  }
+
+  .zr-interior-hero {
+    min-height: 500px;
+  }
+
+  .zr-interior-hero > img {
+    object-position: 62% center;
+  }
+
+  .zr-interior-hero__shade {
+    background:
+      linear-gradient(0deg, rgba(3, 20, 38, .99) 8%, rgba(3, 26, 48, .78)),
+      linear-gradient(90deg, rgba(3, 20, 38, .9), rgba(3, 26, 48, .38));
+  }
+
+  .zr-interior-hero__content {
+    padding-top: 70px;
+    padding-bottom: 76px;
+  }
+
+  .zr-interior-hero__content h1 {
+    font-size: clamp(2.65rem, 12vw, 3.7rem) !important;
+    line-height: 1 !important;
+  }
+
+  .zr-interior-hero__content > p {
+    margin-top: 19px;
+    font-size: .9rem;
+    line-height: 1.65;
+  }
+
+  .zr-interior-hero__actions {
+    flex-direction: column;
+    margin-top: 24px;
+  }
+
+  .zr-interior-hero__actions .zr-button {
+    width: 100%;
+  }
+
+  .zr-interior-trust__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .zr-interior-trust__grid > span {
+    min-height: 82px;
+    padding: 14px 10px 14px 39px;
+  }
+
+  .zr-interior-trust__grid > span::before {
+    left: 10px;
+    width: 19px;
+    height: 19px;
+  }
+
+  .zr-interior-trust__grid > span:nth-child(3) {
+    border-top: 1px solid rgba(6, 41, 75, .1);
+    border-left: 0;
+  }
+
+  .zr-interior-trust__grid > span:nth-child(4) {
+    border-top: 1px solid rgba(6, 41, 75, .1);
+  }
+
+  .zr-interior-trust__grid b {
+    font-size: .65rem;
+  }
+
+  .zr-interior-trust__grid small {
+    font-size: .55rem;
+  }
+
+  .zr-about-copy h2,
+  .zr-section-heading h2,
+  .zr-standard-copy h2,
+  .zr-area-card h2 {
+    font-size: clamp(2.15rem, 10vw, 3.05rem) !important;
+    line-height: 1.05 !important;
+  }
+
+  .zr-about-copy > p,
+  .zr-standard-copy > p {
+    font-size: .88rem;
+  }
+
+  .zr-about-proof,
+  .zr-standard-grid {
+    gap: 55px;
+  }
+
+  .zr-about-visual {
+    padding: 0 24px 38px 0;
+  }
+
+  .zr-about-visual::before {
+    left: 27px;
+  }
+
+  .zr-about-license {
+    width: 235px;
+    padding: 18px;
+    border-width: 5px;
+  }
+
+  .zr-roots-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .zr-roots-grid article {
+    min-height: 0;
+    padding: 28px;
+  }
+
+  .zr-roots-grid h3 {
+    margin-top: 42px;
+  }
+
+  .zr-standard-photo {
+    min-height: 410px;
+    border-width: 7px;
+    border-radius: 24px;
+  }
+
+  .zr-area-card {
+    width: min(100% - 28px, 1240px);
+    padding: 34px 22px;
+    border-radius: 24px;
+  }
+
+  .zr-area-actions {
+    display: grid;
+  }
+
+  .zr-area-actions .zr-button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 410px) {
+  .zr-interior-trust__grid > span {
+    padding-right: 6px;
+    padding-left: 35px;
+  }
+
+  .zr-interior-trust__grid > span::before {
+    left: 7px;
+  }
+
+  .zr-about-license {
+    width: 218px;
+  }
+
+  .zr-standard-photo {
+    min-height: 350px;
+  }
+}
+
 /* End Zenith Premium System */

--- a/js/header.js
+++ b/js/header.js
@@ -1,174 +1,101 @@
-/* =======================================================================
-   js/header.js — Desktop dropdowns + Mobile off-canvas (single file)
-   - Desktop: optional .submenu-toggle click handler (if you use it)
-   - Mobile: .menu-toggle opens/closes off-canvas by toggling body.nav-open
-   - Mobile accordions: .accordion-toggle expands nested <li> menus
-   - Click-outside, ESC to close, resize cleanup
-   - Idempotent: safe to call window.ZenithHeader.init() multiple times
-   - Legacy alias: window.initMobileMenu() calls the same init
-   ======================================================================= */
+/* Shared premium header, mobile drawer, active navigation and quick-action dock. */
 (() => {
-  'use strict';
+  "use strict";
 
-  // Guards so we don’t double-bind global listeners
-  let desktopBound = false;
-  let outsideClickBound = false;
-  let escBound = false;
-  let resizeBound = false;
+  const boundOpeners = new WeakSet();
+  const boundClosers = new WeakSet();
+  const boundDrawers = new WeakSet();
+  let globalBound = false;
 
-  // Cache current bound elements so we only bind once per element
-  const boundMenuToggles = new WeakSet();
-  let boundMobileNav  = null;
+  const elements = () => ({
+    drawer: document.querySelector(".mobile-drawer"),
+    backdrop: document.querySelector(".drawer-backdrop"),
+    openers: document.querySelectorAll(".menu-button, .mobile-dock__menu"),
+    closers: document.querySelectorAll(".mobile-drawer__close"),
+  });
 
-  // --- Utilities ---
-  const isOpen = () => document.body.classList.contains('nav-open');
   const syncExpanded = (expanded) => {
-    document.querySelectorAll('.menu-toggle, .zr-dock-menu')
-      .forEach((toggle) => toggle.setAttribute('aria-expanded', String(expanded)));
+    document.querySelectorAll(".menu-button, .mobile-dock__menu").forEach((button) => {
+      button.setAttribute("aria-expanded", String(expanded));
+      if (button.classList.contains("menu-button")) {
+        button.setAttribute("aria-label", expanded ? "Close navigation" : "Open navigation");
+      }
+    });
   };
-  const openMobile = () => {
-    document.body.classList.add('nav-open');
-    syncExpanded(true);
-    document.body.style.overflow = 'hidden';
+
+  const setMenu = (open) => {
+    const { drawer, backdrop } = elements();
+    if (!drawer || !backdrop) return;
+
+    drawer.classList.toggle("is-open", open);
+    backdrop.classList.toggle("is-open", open);
+    drawer.setAttribute("aria-hidden", String(!open));
+    document.body.classList.toggle("menu-open", open);
+    document.body.style.overflow = open ? "hidden" : "";
+    syncExpanded(open);
   };
-  const closeMobile = () => {
-    document.body.classList.remove('nav-open');
-    syncExpanded(false);
-    document.body.style.overflow = '';
-  };
-  const isMobileViewport = () => window.matchMedia('(max-width: 1024px)').matches; // matches your CSS
 
-  // --- [A] Desktop dropdowns (optional click support) ---
-  // If you add .submenu-toggle to desktop triggers, this will handle click-to-toggle
-  function bindDesktopDropdowns() {
-    if (desktopBound) return;
-    document.addEventListener('click', (e) => {
-      const toggle = e.target.closest('.submenu-toggle');
-      if (!toggle) return;
+  const setActiveNavigation = () => {
+    const path = window.location.pathname.replace(/\/+$/, "") || "/";
+    const matches = (href) => {
+      const target = new URL(href, window.location.origin).pathname.replace(/\/+$/, "") || "/";
+      return target === "/" ? path === "/" : path === target || path.startsWith(`${target}/`);
+    };
 
-      const li = toggle.closest('li');
-      const parentUl = li?.parentElement;
-      if (!li || !parentUl) return;
-
-      // Close siblings
-      parentUl.querySelectorAll(':scope > li.open').forEach((openLi) => {
-        if (openLi !== li) {
-          openLi.classList.remove('open');
-          openLi.querySelectorAll('.submenu-toggle,[aria-expanded]')
-                .forEach((b) => b.setAttribute('aria-expanded', 'false'));
-        }
-      });
-
-      // Toggle current
-      const nowOpen = li.classList.toggle('open');
-      toggle.setAttribute('aria-expanded', String(nowOpen));
-
-      // Prevent accidental nav if the toggle is an <a>
-      if (toggle.tagName === 'A') e.preventDefault();
-    }, { passive: false });
-    desktopBound = true;
-  }
-
-  // --- [B] Mobile: off-canvas open/close & helpers ---
-  function bindMobileControls() {
-    const menuToggle = document.querySelector('.menu-toggle');
-    const menuToggles = document.querySelectorAll('.menu-toggle, .zr-dock-menu');
-    const mobileNav  = document.querySelector('.mobile-nav');
-
-    // If either element is missing, nothing to bind (ok on desktop-only pages)
-    if (!menuToggle || !mobileNav || !menuToggles.length) return;
-
-    // Bind hamburger only once per element
-    menuToggles.forEach((toggle) => {
-      if (boundMenuToggles.has(toggle)) return;
-      toggle.addEventListener('click', () => {
-        const opening = !isOpen();
-        opening ? openMobile() : closeMobile();
-      });
-      boundMenuToggles.add(toggle);
+    document.querySelectorAll(".desktop-nav > a").forEach((link) => {
+      const active = matches(link.getAttribute("href"));
+      link.classList.toggle("is-active", active);
+      if (active) link.setAttribute("aria-current", "page");
+      else link.removeAttribute("aria-current");
     });
 
-    // Click outside to close (bind once globally)
-    if (!outsideClickBound) {
-      document.addEventListener('click', (e) => {
-        if (!isOpen()) return;
-        // Don’t close if clicking inside the panel or on the toggle
-        if (mobileNav.contains(e.target) || e.target.closest('.menu-toggle, .zr-dock-menu')) return;
-        closeMobile(menuToggle);
-      });
-      outsideClickBound = true;
-    }
-
-    // ESC to close (bind once globally)
-    if (!escBound) {
-      document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && isOpen()) closeMobile(menuToggle);
-      });
-      escBound = true;
-    }
-
-    // On resize to desktop, clean up (bind once globally)
-    if (!resizeBound) {
-      let lastIsMobile = isMobileViewport();
-      window.addEventListener('resize', () => {
-        const nowIsMobile = isMobileViewport();
-        if (lastIsMobile && !nowIsMobile) closeMobile(menuToggle);
-        lastIsMobile = nowIsMobile;
-      });
-      resizeBound = true;
-    }
-
-
-    // Delegate mobile nav clicks once per injected mobileNav element.
-    // This handles both normal links and accordion buttons without double-binding.
-    if (boundMobileNav !== mobileNav) {
-      mobileNav.addEventListener('click', (e) => {
-        const btn = e.target.closest('.accordion-toggle');
-        if (btn) {
-          e.preventDefault();
-          e.stopPropagation();
-
-          const li = btn.closest('li');
-          if (!li) return;
-
-          li.parentElement?.querySelectorAll(':scope > li.open').forEach((openLi) => {
-            if (openLi !== li) {
-              openLi.classList.remove('open');
-              openLi.querySelectorAll('.accordion-toggle,[aria-expanded]')
-                    .forEach((b) => b.setAttribute('aria-expanded', 'false'));
-            }
-          });
-
-          const now = li.classList.toggle('open');
-          btn.setAttribute('aria-expanded', String(now));
-          return;
-        }
-
-        const link = e.target.closest('a[href]');
-        if (link) closeMobile(menuToggle);
-      }, { passive: false });
-
-      boundMobileNav = mobileNav;
-    }
-  }
+    const services = document.querySelector(".nav-mega");
+    if (services) services.classList.toggle("is-active", path === "/services" || path.startsWith("/services/"));
+  };
 
   function init() {
-    // Desktop click support (safe if you only use :hover in CSS too)
-    bindDesktopDropdowns();
+    const { drawer, backdrop, openers, closers } = elements();
+    if (!drawer || !backdrop) return;
 
-    // Mobile controls & accordions
-    bindMobileControls();
+    setActiveNavigation();
+
+    openers.forEach((button) => {
+      if (boundOpeners.has(button)) return;
+      button.addEventListener("click", () => setMenu(!drawer.classList.contains("is-open")));
+      boundOpeners.add(button);
+    });
+
+    closers.forEach((button) => {
+      if (boundClosers.has(button)) return;
+      button.addEventListener("click", () => setMenu(false));
+      boundClosers.add(button);
+    });
+
+    if (!boundDrawers.has(drawer)) {
+      drawer.addEventListener("click", (event) => {
+        if (event.target.closest("a[href]")) setMenu(false);
+      });
+      backdrop.addEventListener("click", () => setMenu(false));
+      boundDrawers.add(drawer);
+    }
+
+    if (!globalBound) {
+      document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") setMenu(false);
+      });
+      window.addEventListener("resize", () => {
+        if (window.innerWidth > 960) setMenu(false);
+      });
+      globalBound = true;
+    }
   }
 
-  // Auto-init on DOM ready (safe: idempotent)
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init, { once: true });
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
   } else {
     init();
   }
 
-  // Expose for your include loader (safe to call multiple times)
   window.ZenithHeader = { init };
-  // Legacy alias so existing calls to initMobileMenu() keep working
-  window.initMobileMenu = () => window.ZenithHeader.init();
+  window.initMobileMenu = init;
 })();

--- a/js/header.js
+++ b/js/header.js
@@ -43,7 +43,11 @@
     };
 
     document.querySelectorAll(".desktop-nav > a").forEach((link) => {
-      const active = matches(link.getAttribute("href"));
+      const href = link.getAttribute("href");
+      const resourceLink = href === "/blog/";
+      const active = resourceLink
+        ? ["/blog", "/glossary", "/youtube"].some((section) => path === section || path.startsWith(`${section}/`))
+        : matches(href);
       link.classList.toggle("is-active", active);
       if (active) link.setAttribute("aria-current", "page");
       else link.removeAttribute("aria-current");


### PR DESCRIPTION
## Exact premium-site port

This update ports the actual component structure and measurements from `zenith-roofing-premium` into the real Zenith website.

### Included

- exact premium trust ribbon and translucent sticky header
- exact navigation proportions, active states, logo treatment, and CTA
- Bryan's approved three-column Services mega menu:
  - Repair & Maintenance
  - Roofing Systems
  - Property Services
- exact premium mobile drawer and permanent Call / Text / Estimate / Menu dock
- exact About page structure: full-bleed hero, four-part trust strip, and company proof layout
- exact premium CTA footer and information grid
- removal of the extra sections from the earlier approximation
- removal of duplicate legacy mobile action bars
- existing URLs, SEO metadata, schema, phone links, and contact links preserved

### Live verification

- visually inspected the deployed About page at 1363 × 936
- opened and inspected the Services mega menu
- verified the shared premium header on the Reviews page
- confirmed the page produces no site console errors
- confirmed all header navigation targets exist in the repository
- confirmed every uploaded GitHub blob exactly matches its local source file
- `node --check js/header.js`
- `git diff --check`

This remains a draft for Bryan's visual approval before merging.