### PR TITLE
Add Flat Roof Repair and fix Property Services navigation

### DIFF
--- a/components/header-section.html
+++ b/components/header-section.html
@@ -25,8 +25,8 @@
             <a href="/services/roof-repairs/roof-tune-up/">Roof Tune-Up <span>→</span></a>
             <a href="/services/roof-repairs/tile-roof-repair/">Tile Roof Repair <span>→</span></a>
             <a href="/services/roof-repairs/clay-tile-roof-repair/">Clay Tile Repair <span>→</span></a>
+            <a href="/services/roof-repairs/flat-roof-repair/">Flat Roof Repair <span>→</span></a>
             <a href="/services/roof-repairs/skylight-repair/">Skylight Repair <span>→</span></a>
-            <a href="/services/roof-inspection/">Roof Inspections <span>→</span></a>
           </div>
           <div>
             <span class="nav-eyebrow">Roofing Systems</span>
@@ -40,6 +40,7 @@
           <div class="nav-mega__feature">
             <span class="nav-eyebrow">Property Services</span>
             <a href="/services/commercial/">Commercial Roofing <span>→</span></a>
+            <a href="/services/roof-inspection/">Roof Inspections <span>→</span></a>
             <a href="/services/insurance-claims/">Insurance &amp; Storm Claims <span>→</span></a>
             <a href="/services/real-estate/">Real Estate Roofing <span>→</span></a>
             <a href="/services/gutters/">Seamless Gutters <span>→</span></a>
@@ -86,11 +87,13 @@
         <a href="/services/roof-repairs/roof-tune-up/">Roof Tune-Up</a>
         <a href="/services/roof-repairs/tile-roof-repair/">Tile Roof Repair</a>
         <a href="/services/roof-repairs/clay-tile-roof-repair/">Clay Tile Repair</a>
+        <a href="/services/roof-repairs/flat-roof-repair/">Flat Roof Repair</a>
         <a href="/services/roof-repairs/skylight-repair/">Skylight Repair</a>
         <a href="/services/residential/tile-lift-lay/">Tile Lift &amp; Reset</a>
         <a href="/services/commercial/tpo/">TPO Roofing</a>
         <a href="/services/commercial/torch-down/">Torch-Down</a>
         <a href="/services/commercial/silicone-coatings/">Silicone Coatings</a>
+        <a href="/services/roof-inspection/">Roof Inspections</a>
         <a href="/services/gutters/">Seamless Gutters</a>
       </div>
     </details>

--- a/css/zenith-premium-exact.css
+++ b/css/zenith-premium-exact.css
@@ -466,6 +466,28 @@ textarea:focus-visible {
     var(--navy-950);
 }
 
+.nav-mega__panel > .nav-mega__feature > a:not(.text-link) {
+  color: rgba(255, 255, 255, 0.94);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.nav-mega__panel > .nav-mega__feature > a:not(.text-link) span {
+  color: #ffae4d;
+  transition: transform 0.25s var(--ease);
+}
+
+.nav-mega__panel > .nav-mega__feature > a:not(.text-link):hover,
+.nav-mega__panel > .nav-mega__feature > a:not(.text-link):focus-visible {
+  color: var(--white);
+  background: rgba(255, 255, 255, 0.07);
+  box-shadow: 8px 0 0 rgba(255, 255, 255, 0.07), -8px 0 0 rgba(255, 255, 255, 0.07);
+}
+
+.nav-mega__panel > .nav-mega__feature > a:not(.text-link):hover span,
+.nav-mega__panel > .nav-mega__feature > a:not(.text-link):focus-visible span {
+  transform: translateX(4px);
+}
+
 .nav-mega__feature strong {
   max-width: 240px;
   margin: 10px 0;

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="canonical" href="https://www.zenithroofingservices.com/">
   <link rel="icon" href="/zenith-favicon-v3.png">
   <link rel="preload" as="image" href="/images/modern-tile-roof-1600.webp">
-  <link rel="stylesheet" href="/css/zenith-premium-exact.css?v=exact-premium-2">
+  <link rel="stylesheet" href="/css/zenith-premium-exact.css?v=exact-premium-3">
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"RoofingContractor","name":"Zenith Roofing Services, Inc.","telephone":"+1-858-900-6163","url":"https://www.zenithroofingservices.com/","areaServed":["Escondido","San Diego","Temecula","North County San Diego"],"identifier":"CSLB C-39 #1036112"}</script>
 </head>
 <body>


### PR DESCRIPTION
## What changed

- Added **Flat Roof Repair** to the Repair & Maintenance column
- Moved **Roof Inspections** from Repair & Maintenance into Property Services
- Added Flat Roof Repair and Roof Inspections to the mobile menu
- Fixed the low-contrast Property Services links with bright text, orange arrows, and clearer hover/focus feedback
- Bumped the premium stylesheet cache version so the correction loads immediately

## Why

Flat Roof Repair was missing from the service navigation, Roof Inspections fits better under Property Services, and the dark Property Services links were difficult to read against the navy panel.

## Validation

- Verified desktop and mobile menu placement
- Verified both destination pages exist
- Verified the Property Services contrast rules
- `git diff --check` passed
