### PR TITLE
Add persistent Home button to mobile navigation

### DIFF
--- a/components/header-section.html
+++ b/components/header-section.html
@@ -119,6 +119,7 @@
 </aside>
 
 <nav class="mobile-dock" aria-label="Quick actions">
+  <a class="mobile-dock__home" href="/"><span aria-hidden="true">⌂</span>Home</a>
   <a href="tel:8589006163"><span aria-hidden="true">☎</span>Call</a>
   <a href="sms:+18589006163"><span aria-hidden="true">✉</span>Text</a>
   <a class="mobile-dock__primary" href="/contact/"><span aria-hidden="true">＋</span>Estimate</a>

--- a/css/landing-theme-preview.css
+++ b/css/landing-theme-preview.css
@@ -4130,7 +4130,7 @@ textarea:focus {
     left: 0;
     z-index: 1082;
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     padding: 7px 8px calc(7px + env(safe-area-inset-bottom));
     background: rgba(255, 255, 255, .95);
     border-top: 1px solid rgba(6, 41, 75, .12);
@@ -4158,6 +4158,11 @@ textarea:focus {
   .mobile-dock span {
     font-size: 1rem;
     line-height: 1;
+  }
+
+  .mobile-dock .mobile-dock__home.is-active {
+    color: var(--orange-600) !important;
+    background: var(--orange-100);
   }
 
   .mobile-dock .mobile-dock__primary {

--- a/css/zenith-premium-exact.css
+++ b/css/zenith-premium-exact.css
@@ -3750,7 +3750,7 @@ textarea:focus-visible {
     left: 0;
     z-index: 82;
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     padding: 7px 8px calc(7px + env(safe-area-inset-bottom));
     background: rgba(255, 255, 255, 0.95);
     border-top: 1px solid rgba(6, 41, 75, 0.12);
@@ -3778,6 +3778,11 @@ textarea:focus-visible {
   .mobile-dock span {
     font-size: 1rem;
     line-height: 1;
+  }
+
+  .mobile-dock .mobile-dock__home.is-active {
+    color: var(--orange-600);
+    background: var(--orange-100);
   }
 
   .mobile-dock .mobile-dock__primary {

--- a/js/header.js
+++ b/js/header.js
@@ -55,6 +55,14 @@
 
     const services = document.querySelector(".nav-mega");
     if (services) services.classList.toggle("is-active", path === "/services" || path.startsWith("/services/"));
+
+    const mobileHome = document.querySelector(".mobile-dock__home");
+    if (mobileHome) {
+      const active = path === "/";
+      mobileHome.classList.toggle("is-active", active);
+      if (active) mobileHome.setAttribute("aria-current", "page");
+      else mobileHome.removeAttribute("aria-current");
+    }
   };
 
   function init() {


### PR DESCRIPTION
## What changed

- Added a permanent **Home** button to the bottom mobile navigation
- Preserved every existing quick action: Call, Text, Estimate, and Menu
- Updated both active Zenith site themes to use a balanced five-column mobile dock
- Added an active Home state and `aria-current="page"` accessibility feedback on the homepage

## Why

Visitors on deeper service, project, pricing, and service-area pages need a one-tap way to return to the homepage without opening the menu or scrolling to the top.

## Validation

- Confirmed the shared mobile dock contains exactly five actions
- Confirmed both active mobile themes use five equal columns
- Confirmed active-page Home styling and accessibility behavior
- `node --check js/header.js` passed
- `git diff --check` passed
