### PR TITLE
Match Financing page to premium Zenith design

### DIFF
--- a/css/financing-premium.css
+++ b/css/financing-premium.css
@@ -1,0 +1,1372 @@
+/* Premium Financing page — scoped to /financing/. */
+
+.financing-page {
+  overflow: hidden;
+  background: var(--white);
+}
+
+.financing-page h2,
+.financing-page h3,
+.financing-page p {
+  margin-top: 0;
+}
+
+.financing-page .financing-hero {
+  min-height: 720px;
+}
+
+.financing-page .financing-hero > img {
+  object-position: center 52%;
+}
+
+.financing-page .financing-hero .interior-hero__shade {
+  background:
+    linear-gradient(90deg, rgba(3, 20, 38, .99) 0%, rgba(3, 26, 48, .93) 46%, rgba(3, 26, 48, .62) 75%, rgba(3, 26, 48, .45) 100%),
+    linear-gradient(0deg, rgba(3, 26, 48, .64), transparent 62%);
+}
+
+.financing-page .financing-hero__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(330px, .58fr);
+  align-items: center;
+  gap: clamp(55px, 8vw, 125px);
+}
+
+.financing-page .financing-hero__copy h1 {
+  max-width: 940px;
+}
+
+.financing-page .financing-hero__copy > p:not(.financing-hero__fine) {
+  max-width: 760px;
+  margin: 27px 0 0;
+  color: rgba(255, 255, 255, .8);
+  font-size: 1.08rem;
+  line-height: 1.8;
+}
+
+.financing-page .financing-hero__fine {
+  max-width: 760px;
+  margin: 22px 0 0;
+  color: rgba(255, 255, 255, .62);
+  font-size: .72rem;
+  line-height: 1.55;
+}
+
+.financing-page .financing-offer {
+  position: relative;
+  padding: 38px 36px 34px;
+  overflow: hidden;
+  color: var(--white);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, .16), rgba(255, 255, 255, .07)),
+    rgba(3, 26, 48, .35);
+  border: 1px solid rgba(255, 255, 255, .25);
+  border-radius: 28px;
+  box-shadow: 0 28px 70px rgba(2, 15, 29, .34), inset 0 1px 0 rgba(255, 255, 255, .14);
+  backdrop-filter: blur(18px);
+}
+
+.financing-page .financing-offer::after {
+  position: absolute;
+  right: -72px;
+  bottom: -92px;
+  width: 205px;
+  height: 205px;
+  content: "";
+  background: radial-gradient(circle, rgba(255, 130, 0, .24), transparent 68%);
+  border: 1px solid rgba(255, 255, 255, .08);
+  border-radius: 50%;
+}
+
+.financing-page .financing-offer__label {
+  display: inline-flex;
+  padding: 8px 12px;
+  color: #ffd3a6;
+  background: rgba(255, 130, 0, .12);
+  border: 1px solid rgba(255, 154, 57, .28);
+  border-radius: 999px;
+  font-size: .62rem;
+  font-weight: 850;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.financing-page .financing-offer > strong {
+  display: block;
+  margin-top: 25px;
+  color: var(--white);
+  font-size: 1.05rem;
+  font-weight: 760;
+  line-height: 1;
+}
+
+.financing-page .financing-offer > strong span {
+  color: #ff9a39;
+  font-size: clamp(4rem, 6.2vw, 6.25rem);
+  font-weight: 820;
+  letter-spacing: -.08em;
+}
+
+.financing-page .financing-offer h2 {
+  margin: 7px 0 18px;
+  color: var(--white);
+  font-size: 1.42rem;
+  font-weight: 760;
+  letter-spacing: -.035em;
+}
+
+.financing-page .financing-offer p {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 20px;
+  color: rgba(255, 255, 255, .68);
+  font-size: .78rem;
+  line-height: 1.65;
+}
+
+.financing-page .financing-offer .text-link {
+  position: relative;
+  z-index: 1;
+  color: #ffab55;
+  font-size: .72rem;
+}
+
+.financing-page .fin-section {
+  position: relative;
+  padding: 112px 0;
+}
+
+.financing-page .fin-section--mist,
+.financing-page .fin-faq-section {
+  background:
+    radial-gradient(circle at 4% 8%, rgba(42, 131, 196, .09), transparent 25rem),
+    var(--mist);
+}
+
+.financing-page .fin-section-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(310px, .72fr);
+  align-items: end;
+  gap: clamp(48px, 8vw, 118px);
+  margin-bottom: 48px;
+}
+
+.financing-page .fin-section-heading h2,
+.financing-page .calc-copy h2,
+.financing-page .finance-lead-copy h2,
+.financing-page .local-copy h2,
+.financing-page .faq-heading h2 {
+  margin: 0;
+  color: var(--navy-950);
+  font-size: clamp(2.7rem, 4.5vw, 4.7rem);
+  font-weight: 760;
+  letter-spacing: -.06em;
+  line-height: 1.02;
+  text-wrap: balance;
+}
+
+.financing-page .fin-section-heading > p {
+  margin: 0 0 4px;
+  color: var(--ink-700);
+  font-size: 1rem;
+  line-height: 1.78;
+}
+
+.financing-page .benefits {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.financing-page .benefit {
+  position: relative;
+  min-height: 250px;
+  padding: 30px;
+  overflow: hidden;
+  background: var(--white);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 22px;
+  box-shadow: var(--shadow-sm);
+  transition: transform .42s var(--ease), border-color .35s ease, box-shadow .42s var(--ease);
+}
+
+.financing-page .benefit::after {
+  position: absolute;
+  right: -62px;
+  bottom: -78px;
+  width: 165px;
+  height: 165px;
+  content: "";
+  background: radial-gradient(circle, rgba(42, 131, 196, .09), transparent 68%);
+  border-radius: 50%;
+}
+
+.financing-page .benefit:hover {
+  border-color: rgba(237, 106, 0, .34);
+  box-shadow: 0 22px 52px rgba(6, 41, 75, .13);
+  transform: translateY(-6px);
+}
+
+.financing-page .check {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 34px;
+  place-items: center;
+  color: var(--navy-950);
+  background: linear-gradient(135deg, #ffb24e, var(--orange-500));
+  border-radius: 15px;
+  box-shadow: 0 10px 22px rgba(237, 106, 0, .24);
+  font-size: .84rem;
+  font-weight: 950;
+}
+
+.financing-page .benefit strong {
+  display: block;
+  max-width: 260px;
+  color: var(--navy-950);
+  font-size: 1.08rem;
+  letter-spacing: -.025em;
+  line-height: 1.35;
+}
+
+.financing-page .benefit p {
+  max-width: 330px;
+  margin: 13px 0 0;
+  color: var(--ink-500);
+  font-size: .83rem;
+  line-height: 1.7;
+}
+
+.financing-page .fin-note,
+.financing-page .finance-interest-note {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: start;
+  gap: 16px;
+  margin-top: 24px;
+  padding: 22px 24px;
+  color: var(--navy-950);
+  background: linear-gradient(115deg, var(--orange-100), rgba(255, 255, 255, .95));
+  border: 1px solid rgba(237, 106, 0, .22);
+  border-radius: 18px;
+}
+
+.financing-page .fin-note > span,
+.financing-page .finance-interest-note > span {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  color: var(--white);
+  background: var(--navy-900);
+  border-radius: 13px;
+  font-size: .78rem;
+  font-weight: 900;
+}
+
+.financing-page .fin-note p,
+.financing-page .finance-interest-note p {
+  margin: 2px 0 0;
+  color: var(--ink-700);
+  font-size: .82rem;
+  line-height: 1.65;
+}
+
+.financing-page .calc-layout,
+.financing-page .finance-lead-layout {
+  display: grid;
+  grid-template-columns: minmax(0, .78fr) minmax(520px, 1.22fr);
+  align-items: start;
+  gap: clamp(55px, 7vw, 105px);
+}
+
+.financing-page .calc-copy,
+.financing-page .finance-lead-copy {
+  position: sticky;
+  top: 150px;
+}
+
+.financing-page .calc-copy .lead,
+.financing-page .finance-lead-copy .lead {
+  margin: 26px 0 0;
+  color: var(--ink-700);
+  font-size: 1rem;
+  line-height: 1.82;
+}
+
+.financing-page .calc-copy > p:not(.lead) {
+  margin: 20px 0 28px;
+  color: var(--ink-500);
+  font-size: .8rem;
+  line-height: 1.75;
+}
+
+.financing-page .calculator,
+.financing-page .finance-form-card {
+  position: relative;
+  padding: 42px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, .98);
+  border: 1px solid rgba(6, 41, 75, .11);
+  border-radius: 28px;
+  box-shadow: 0 26px 70px rgba(6, 41, 75, .14);
+}
+
+.financing-page .calculator::before,
+.financing-page .finance-form-card::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 5px;
+  content: "";
+  background: linear-gradient(90deg, var(--orange-500), #ffb34e 44%, var(--blue-500));
+}
+
+.financing-page .calculator__heading,
+.financing-page .finance-form-card__head {
+  margin-bottom: 30px;
+  padding-bottom: 26px;
+  border-bottom: 1px solid var(--line);
+}
+
+.financing-page .calculator__heading > span,
+.financing-page .finance-form-card__head > span {
+  color: var(--orange-600);
+  font-size: .65rem;
+  font-weight: 900;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.financing-page .calculator h3,
+.financing-page .finance-form-card h3 {
+  margin: 9px 0 0;
+  color: var(--navy-950);
+  font-size: clamp(1.5rem, 2.2vw, 2rem);
+  font-weight: 760;
+  letter-spacing: -.04em;
+  line-height: 1.15;
+}
+
+.financing-page .finance-form-card__head p {
+  margin: 11px 0 0;
+  color: var(--ink-500);
+  font-size: .75rem;
+  line-height: 1.6;
+}
+
+.financing-page .calculator > label {
+  display: block;
+  margin-bottom: 13px;
+  color: var(--navy-950);
+  font-size: .78rem;
+  font-weight: 800;
+}
+
+.financing-page .amount-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 152px;
+  align-items: center;
+  gap: 22px;
+}
+
+.financing-page .calculator input[type="range"] {
+  width: 100%;
+  height: 7px;
+  appearance: none;
+  background: linear-gradient(90deg, var(--orange-500), var(--blue-500));
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.financing-page .calculator input[type="range"]::-webkit-slider-thumb {
+  width: 23px;
+  height: 23px;
+  appearance: none;
+  background: var(--white);
+  border: 6px solid var(--orange-500);
+  border-radius: 50%;
+  box-shadow: 0 5px 14px rgba(6, 41, 75, .26);
+}
+
+.financing-page .calculator input[type="range"]::-moz-range-thumb {
+  width: 13px;
+  height: 13px;
+  background: var(--white);
+  border: 6px solid var(--orange-500);
+  border-radius: 50%;
+  box-shadow: 0 5px 14px rgba(6, 41, 75, .26);
+}
+
+.financing-page .amount-input {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  padding: 0 15px;
+  background: var(--mist);
+  border: 1px solid rgba(6, 41, 75, .15);
+  border-radius: 13px;
+}
+
+.financing-page .amount-input b {
+  color: var(--orange-600);
+}
+
+.financing-page .amount-input input {
+  width: 100%;
+  min-height: 49px;
+  padding: 0 0 0 5px;
+  color: var(--navy-950);
+  background: transparent;
+  border: 0;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.financing-page .amount-input input:focus {
+  outline: 0;
+}
+
+.financing-page .range-labels {
+  display: flex;
+  justify-content: space-between;
+  margin: 8px 174px 23px 0;
+  color: var(--ink-500);
+  font-size: .66rem;
+}
+
+.financing-page .calc-highlight {
+  position: relative;
+  margin: 0 0 24px;
+  padding: 19px 20px 19px 54px;
+  color: var(--navy-950);
+  background: linear-gradient(115deg, #eef7fd, #f8fbfd);
+  border: 1px solid rgba(42, 131, 196, .15);
+  border-radius: 16px;
+  font-size: .82rem;
+  font-weight: 780;
+  line-height: 1.55;
+}
+
+.financing-page .calc-highlight::before {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  color: var(--white);
+  content: "$";
+  background: var(--blue-500);
+  border-radius: 8px;
+  font-size: .68rem;
+}
+
+.financing-page .calc-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 15px;
+}
+
+.financing-page .calc-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .75rem;
+}
+
+.financing-page .calc-table th,
+.financing-page .calc-table td {
+  padding: 14px 13px;
+  border-bottom: 1px solid var(--line);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.financing-page .calc-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.financing-page .calc-table th:first-child,
+.financing-page .calc-table td:first-child {
+  text-align: left;
+}
+
+.financing-page .calc-table th {
+  color: var(--navy-950);
+  background: var(--mist);
+  font-size: .61rem;
+  font-weight: 900;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+
+.financing-page .calc-table td:last-child {
+  color: var(--navy-950);
+  font-weight: 800;
+}
+
+.financing-page .calc-disclaimer,
+.financing-page .form-privacy {
+  margin: 17px 0 0;
+  color: var(--ink-500);
+  font-size: .66rem;
+  line-height: 1.6;
+}
+
+.financing-page .finance-lead-copy .finance-interest-note {
+  margin-top: 28px;
+}
+
+.financing-page .finance-inline-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 24px;
+  color: var(--navy-800);
+  font-size: .76rem;
+  font-weight: 820;
+}
+
+.financing-page .finance-inline-link span {
+  color: var(--orange-600);
+  transition: transform .3s var(--ease);
+}
+
+.financing-page .finance-inline-link:hover span {
+  transform: translateX(5px);
+}
+
+.financing-page .finance-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 17px;
+}
+
+.financing-page .finance-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.financing-page .finance-form-field.full {
+  grid-column: 1 / -1;
+}
+
+.financing-page .finance-form-field label {
+  color: var(--navy-950);
+  font-size: .7rem;
+  font-weight: 800;
+}
+
+.financing-page .finance-form-field input,
+.financing-page .finance-form-field select,
+.financing-page .finance-form-field textarea {
+  width: 100%;
+  min-height: 52px;
+  padding: 13px 14px;
+  color: var(--ink-950);
+  background: #fbfcfd;
+  border: 1px solid rgba(6, 41, 75, .16);
+  border-radius: 12px;
+  font-size: 16px;
+  transition: border-color .25s ease, box-shadow .25s ease, background-color .25s ease;
+}
+
+.financing-page .finance-form-field textarea {
+  min-height: 125px;
+  resize: vertical;
+}
+
+.financing-page .finance-form-field input:hover,
+.financing-page .finance-form-field select:hover,
+.financing-page .finance-form-field textarea:hover {
+  background: var(--white);
+  border-color: rgba(6, 41, 75, .3);
+}
+
+.financing-page .finance-form-field input:focus,
+.financing-page .finance-form-field select:focus,
+.financing-page .finance-form-field textarea:focus {
+  background: var(--white);
+  border-color: var(--orange-500);
+  box-shadow: 0 0 0 4px rgba(255, 130, 0, .11);
+  outline: 0;
+}
+
+.financing-page .finance-form.was-validated :invalid {
+  background: #fff9f9;
+  border-color: #b72727;
+  box-shadow: 0 0 0 3px rgba(183, 39, 39, .1);
+}
+
+.financing-page .finance-recaptcha {
+  min-height: 78px;
+  margin-top: 19px;
+}
+
+.financing-page .finance-form-submit {
+  margin-top: 15px;
+  border: 0;
+  cursor: pointer;
+}
+
+.financing-page .finance-form-submit:disabled {
+  cursor: wait;
+  opacity: .64;
+}
+
+.financing-page .finance-form-status {
+  min-height: 22px;
+  margin-top: 12px;
+  font-size: .74rem;
+  font-weight: 780;
+  line-height: 1.5;
+}
+
+.financing-page .finance-form-status.error {
+  color: #a61b1b;
+}
+
+.financing-page .finance-form-status.success {
+  color: #087c55;
+}
+
+.financing-page .fin-process {
+  color: var(--white);
+  background:
+    radial-gradient(circle at 93% 9%, rgba(42, 131, 196, .22), transparent 28rem),
+    radial-gradient(circle at 5% 90%, rgba(255, 130, 0, .09), transparent 24rem),
+    linear-gradient(145deg, var(--navy-950), #052846);
+}
+
+.financing-page .fin-section-heading--light h2,
+.financing-page .fin-section-heading--light > p {
+  color: var(--white);
+}
+
+.financing-page .fin-section-heading--light > p {
+  color: rgba(255, 255, 255, .65);
+}
+
+.financing-page .steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.financing-page .step {
+  position: relative;
+  min-height: 295px;
+  padding: 34px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, .055);
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: 24px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .05);
+  transition: transform .4s var(--ease), background-color .3s ease, border-color .3s ease;
+}
+
+.financing-page .step:hover {
+  background: rgba(255, 255, 255, .09);
+  border-color: rgba(255, 154, 57, .35);
+  transform: translateY(-6px);
+}
+
+.financing-page .step-num {
+  display: inline-flex;
+  margin-bottom: 47px;
+  color: #ff9a39;
+  font-size: .7rem;
+  font-weight: 900;
+  letter-spacing: .1em;
+}
+
+.financing-page .step-num::after {
+  width: 46px;
+  height: 1px;
+  margin: 7px 0 0 13px;
+  content: "";
+  background: rgba(255, 255, 255, .24);
+}
+
+.financing-page .step h3 {
+  margin-bottom: 13px;
+  color: var(--white);
+  font-size: 1.25rem;
+  font-weight: 740;
+  letter-spacing: -.035em;
+}
+
+.financing-page .step p {
+  margin: 0;
+  color: rgba(255, 255, 255, .62);
+  font-size: .82rem;
+  line-height: 1.72;
+}
+
+.financing-page .services {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 15px;
+}
+
+.financing-page .service-card {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--white);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 22px;
+  box-shadow: var(--shadow-sm);
+  transition: transform .42s var(--ease), box-shadow .42s var(--ease), border-color .3s ease;
+}
+
+.financing-page .service-card:hover {
+  border-color: rgba(237, 106, 0, .3);
+  box-shadow: 0 24px 58px rgba(6, 41, 75, .15);
+  transform: translateY(-7px);
+}
+
+.financing-page .service-card__media {
+  position: relative;
+  height: 205px;
+  overflow: hidden;
+}
+
+.financing-page .service-card__media::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(0deg, rgba(3, 26, 48, .66), transparent 58%);
+}
+
+.financing-page .service-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform .75s var(--ease);
+}
+
+.financing-page .service-card:hover .service-card__media img {
+  transform: scale(1.06);
+}
+
+.financing-page .service-card__media span {
+  position: absolute;
+  right: 16px;
+  bottom: 15px;
+  z-index: 2;
+  padding: 7px 10px;
+  color: var(--white);
+  background: rgba(3, 26, 48, .52);
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: 999px;
+  font-size: .56rem;
+  font-weight: 850;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  backdrop-filter: blur(10px);
+}
+
+.financing-page .service-card__body {
+  padding: 25px;
+}
+
+.financing-page .service-card h3 {
+  margin-bottom: 11px;
+  color: var(--navy-950);
+  font-size: 1.02rem;
+  line-height: 1.35;
+}
+
+.financing-page .service-card p {
+  margin: 0;
+  color: var(--ink-500);
+  font-size: .76rem;
+  line-height: 1.7;
+}
+
+.financing-page .fin-local {
+  background:
+    radial-gradient(circle at 80% 20%, rgba(42, 131, 196, .12), transparent 24rem),
+    linear-gradient(145deg, #eef4f8, #f9fbfc);
+}
+
+.financing-page .fin-local__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(330px, .55fr);
+  align-items: center;
+  gap: clamp(55px, 9vw, 135px);
+}
+
+.financing-page .local-copy > p {
+  max-width: 800px;
+  margin: 24px 0 0;
+  color: var(--ink-700);
+  font-size: .9rem;
+  line-height: 1.82;
+}
+
+.financing-page .internal-links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 30px;
+}
+
+.financing-page .internal-links a {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 15px;
+  padding: 14px 17px;
+  color: var(--navy-950);
+  background: rgba(255, 255, 255, .88);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 14px;
+  font-size: .7rem;
+  font-weight: 800;
+  transition: transform .3s var(--ease), border-color .3s ease, box-shadow .3s var(--ease);
+}
+
+.financing-page .internal-links a span {
+  color: var(--orange-600);
+  transition: transform .3s var(--ease);
+}
+
+.financing-page .internal-links a:hover {
+  border-color: rgba(237, 106, 0, .32);
+  box-shadow: 0 12px 28px rgba(6, 41, 75, .08);
+  transform: translateY(-3px);
+}
+
+.financing-page .internal-links a:hover span {
+  transform: translate(3px, -3px);
+}
+
+.financing-page .local-finance-card {
+  position: relative;
+  padding: 36px;
+  overflow: hidden;
+  color: var(--white);
+  background:
+    radial-gradient(circle at 95% 0%, rgba(42, 131, 196, .3), transparent 44%),
+    linear-gradient(145deg, var(--navy-800), var(--navy-950));
+  border-radius: 28px;
+  box-shadow: var(--shadow-lg);
+}
+
+.financing-page .local-finance-card__icon {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  margin-bottom: 35px;
+  place-items: center;
+  color: var(--navy-950);
+  background: linear-gradient(135deg, #ffb24e, var(--orange-500));
+  border-radius: 17px;
+  font-size: 1rem;
+  box-shadow: 0 12px 28px rgba(237, 106, 0, .25);
+}
+
+.financing-page .local-finance-card small {
+  display: block;
+  margin-bottom: 9px;
+  color: #ffab55;
+  font-size: .62rem;
+  font-weight: 850;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.financing-page .local-finance-card strong {
+  display: block;
+  color: var(--white);
+  font-size: 1.55rem;
+  letter-spacing: -.04em;
+  line-height: 1.2;
+}
+
+.financing-page .local-finance-card p {
+  margin: 17px 0 27px;
+  color: rgba(255, 255, 255, .65);
+  font-size: .8rem;
+  line-height: 1.7;
+}
+
+.financing-page .faq-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, .56fr) minmax(0, 1.1fr);
+  align-items: start;
+  gap: clamp(55px, 9vw, 140px);
+}
+
+.financing-page .faq-heading {
+  position: sticky;
+  top: 150px;
+}
+
+.financing-page .faq-heading p {
+  margin: 24px 0 28px;
+  color: var(--ink-700);
+  font-size: .88rem;
+  line-height: 1.8;
+}
+
+.financing-page .faq details {
+  margin: 0;
+  background: rgba(255, 255, 255, .95);
+  border: 1px solid rgba(6, 41, 75, .11);
+  border-radius: 16px;
+  box-shadow: 0 8px 25px rgba(6, 41, 75, .04);
+  transition: border-color .3s ease, box-shadow .3s var(--ease);
+}
+
+.financing-page .faq details + details {
+  margin-top: 10px;
+}
+
+.financing-page .faq details[open] {
+  border-color: rgba(237, 106, 0, .34);
+  box-shadow: 0 16px 38px rgba(6, 41, 75, .08);
+}
+
+.financing-page .faq summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 31px;
+  align-items: center;
+  gap: 20px;
+  padding: 21px 23px;
+  color: var(--navy-950);
+  cursor: pointer;
+  font-size: .82rem;
+  font-weight: 800;
+  line-height: 1.45;
+  list-style: none;
+}
+
+.financing-page .faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.financing-page .faq summary span {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  place-items: center;
+  color: var(--orange-600);
+  background: var(--orange-100);
+  border-radius: 10px;
+  font-size: 1rem;
+  transition: transform .3s var(--ease), color .3s ease, background-color .3s ease;
+}
+
+.financing-page .faq details[open] summary span {
+  color: var(--white);
+  background: var(--navy-900);
+  transform: rotate(45deg);
+}
+
+.financing-page .faq details p {
+  margin: -2px 23px 0;
+  padding: 0 51px 23px 0;
+  color: var(--ink-500);
+  font-size: .78rem;
+  line-height: 1.75;
+}
+
+.financing-page .fin-cta {
+  position: relative;
+  padding: 96px 0;
+  overflow: hidden;
+  color: var(--white);
+  background:
+    radial-gradient(circle at 85% 35%, rgba(42, 131, 196, .25), transparent 27rem),
+    linear-gradient(135deg, #041d34, var(--navy-900));
+}
+
+.financing-page .fin-cta::after {
+  position: absolute;
+  right: -190px;
+  bottom: -260px;
+  width: 570px;
+  height: 570px;
+  content: "";
+  border: 1px solid rgba(255, 255, 255, .07);
+  border-radius: 50%;
+  box-shadow: 0 0 0 80px rgba(255, 255, 255, .018), 0 0 0 160px rgba(255, 255, 255, .01);
+}
+
+.financing-page .fin-cta__inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 35px 70px;
+}
+
+.financing-page .fin-cta h2 {
+  max-width: 780px;
+  margin: 0;
+  color: var(--white);
+  font-size: clamp(2.6rem, 4.7vw, 4.8rem);
+  font-weight: 760;
+  letter-spacing: -.06em;
+  line-height: 1.02;
+}
+
+.financing-page .fin-cta div > p {
+  margin: 20px 0 0;
+  color: rgba(255, 255, 255, .67);
+  font-size: .95rem;
+}
+
+.financing-page .fin-cta .disclosure {
+  grid-column: 1 / -1;
+  max-width: 1160px;
+  margin: 6px 0 0;
+  padding-top: 27px;
+  color: rgba(255, 255, 255, .5);
+  border-top: 1px solid rgba(255, 255, 255, .12);
+  font-size: .62rem;
+  line-height: 1.7;
+}
+
+@media (min-width: 1440px) {
+  .trust-ribbon .shell,
+  .site-header .shell,
+  .financing-page .shell,
+  .site-footer .shell {
+    width: min(1540px, calc(100% - 136px));
+  }
+
+  .financing-page .financing-hero {
+    min-height: 810px;
+  }
+
+  .financing-page .financing-hero__copy h1 {
+    max-width: 1080px;
+    font-size: clamp(5.3rem, 5.7vw, 7rem) !important;
+  }
+
+  .financing-page .financing-hero__copy > p:not(.financing-hero__fine) {
+    max-width: 900px;
+    font-size: 1.22rem;
+  }
+
+  .financing-page .financing-offer {
+    padding: 44px 42px 40px;
+  }
+
+  .financing-page .fin-section {
+    padding: 145px 0;
+  }
+
+  .financing-page .fin-section-heading > p,
+  .financing-page .calc-copy .lead,
+  .financing-page .finance-lead-copy .lead {
+    font-size: 1.08rem;
+  }
+
+  .financing-page .benefit {
+    min-height: 280px;
+    padding: 36px;
+  }
+
+  .financing-page .services {
+    gap: 20px;
+  }
+
+  .financing-page .service-card__media {
+    height: 240px;
+  }
+}
+
+@media (max-width: 1120px) {
+  .financing-page .financing-hero__content {
+    grid-template-columns: minmax(0, 1fr) 300px;
+    gap: 45px;
+  }
+
+  .financing-page .calc-layout,
+  .financing-page .finance-lead-layout {
+    grid-template-columns: minmax(0, .76fr) minmax(470px, 1.24fr);
+    gap: 48px;
+  }
+
+  .financing-page .services {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 960px) {
+  .financing-page .financing-hero {
+    min-height: auto;
+  }
+
+  .financing-page .financing-hero__content {
+    grid-template-columns: 1fr;
+    gap: 38px;
+    padding-top: 82px;
+    padding-bottom: 74px;
+  }
+
+  .financing-page .financing-offer {
+    width: min(100%, 580px);
+  }
+
+  .financing-page .fin-section-heading,
+  .financing-page .calc-layout,
+  .financing-page .finance-lead-layout,
+  .financing-page .fin-local__layout,
+  .financing-page .faq-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .financing-page .fin-section-heading {
+    align-items: start;
+    gap: 20px;
+  }
+
+  .financing-page .fin-section-heading > p {
+    max-width: 720px;
+  }
+
+  .financing-page .calc-layout,
+  .financing-page .finance-lead-layout,
+  .financing-page .fin-local__layout,
+  .financing-page .faq-layout {
+    gap: 45px;
+  }
+
+  .financing-page .calc-copy,
+  .financing-page .finance-lead-copy,
+  .financing-page .faq-heading {
+    position: static;
+  }
+
+  .financing-page .local-finance-card {
+    width: min(100%, 600px);
+  }
+}
+
+@media (max-width: 760px) {
+  .financing-page .financing-hero > img {
+    object-position: 59% center;
+  }
+
+  .financing-page .financing-hero .interior-hero__shade {
+    background: linear-gradient(90deg, rgba(3, 20, 38, .97), rgba(3, 26, 48, .78));
+  }
+
+  .financing-page .interior-trust__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .financing-page .interior-trust__grid > span:nth-child(3) {
+    border-left: 0;
+  }
+
+  .financing-page .interior-trust__grid > span:nth-child(n + 3) {
+    border-top: 1px solid rgba(6, 41, 75, .1);
+  }
+
+  .financing-page .fin-section {
+    padding: 82px 0;
+  }
+
+  .financing-page .benefits,
+  .financing-page .steps {
+    grid-template-columns: 1fr;
+  }
+
+  .financing-page .benefit,
+  .financing-page .step {
+    min-height: auto;
+  }
+
+  .financing-page .calculator,
+  .financing-page .finance-form-card {
+    padding: 31px 25px;
+    border-radius: 23px;
+  }
+
+  .financing-page .amount-row {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .financing-page .range-labels {
+    margin-right: 0;
+  }
+
+  .financing-page .finance-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .financing-page .finance-form-field.full {
+    grid-column: auto;
+  }
+
+  .financing-page .fin-cta {
+    padding: 78px 0 88px;
+  }
+
+  .financing-page .fin-cta__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .financing-page .fin-cta .button {
+    justify-self: start;
+  }
+}
+
+@media (max-width: 560px) {
+  .financing-page .financing-hero__content {
+    padding-top: 68px;
+    padding-bottom: 62px;
+  }
+
+  .financing-page .financing-hero__copy h1 {
+    font-size: clamp(2.75rem, 13.2vw, 3.7rem) !important;
+  }
+
+  .financing-page .financing-hero__copy > p:not(.financing-hero__fine) {
+    font-size: .9rem;
+    line-height: 1.7;
+  }
+
+  .financing-page .interior-hero__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .financing-page .interior-hero__actions .button {
+    width: 100%;
+  }
+
+  .financing-page .financing-offer {
+    padding: 28px 24px 26px;
+    border-radius: 22px;
+  }
+
+  .financing-page .financing-offer > strong span {
+    font-size: 4rem;
+  }
+
+  .financing-page .interior-trust__grid > span {
+    min-height: 88px;
+    padding: 14px 12px 14px 36px;
+  }
+
+  .financing-page .interior-trust__grid > span::before {
+    left: 10px;
+  }
+
+  .financing-page .interior-trust__grid b {
+    font-size: .68rem;
+  }
+
+  .financing-page .interior-trust__grid small {
+    font-size: .57rem;
+  }
+
+  .financing-page .fin-section-heading h2,
+  .financing-page .calc-copy h2,
+  .financing-page .finance-lead-copy h2,
+  .financing-page .local-copy h2,
+  .financing-page .faq-heading h2,
+  .financing-page .fin-cta h2 {
+    font-size: clamp(2.45rem, 12vw, 3.2rem);
+  }
+
+  .financing-page .benefit {
+    padding: 26px;
+  }
+
+  .financing-page .fin-note,
+  .financing-page .finance-interest-note {
+    grid-template-columns: 36px minmax(0, 1fr);
+    gap: 13px;
+    padding: 18px;
+  }
+
+  .financing-page .fin-note > span,
+  .financing-page .finance-interest-note > span {
+    width: 36px;
+    height: 36px;
+  }
+
+  .financing-page .calculator,
+  .financing-page .finance-form-card {
+    padding: 28px 19px;
+  }
+
+  .financing-page .calc-highlight {
+    padding-left: 50px;
+  }
+
+  .financing-page .calc-table {
+    font-size: .7rem;
+  }
+
+  .financing-page .calc-table th,
+  .financing-page .calc-table td {
+    padding: 12px 10px;
+  }
+
+  .financing-page .finance-recaptcha {
+    width: 113.7%;
+    min-height: 70px;
+    transform: scale(.88);
+    transform-origin: left top;
+  }
+
+  .financing-page .services,
+  .financing-page .internal-links {
+    grid-template-columns: 1fr;
+  }
+
+  .financing-page .service-card__media {
+    height: 220px;
+  }
+
+  .financing-page .step {
+    padding: 28px;
+  }
+
+  .financing-page .step-num {
+    margin-bottom: 34px;
+  }
+
+  .financing-page .local-finance-card {
+    padding: 29px 24px;
+    border-radius: 23px;
+  }
+
+  .financing-page .faq summary {
+    gap: 13px;
+    padding: 18px;
+  }
+
+  .financing-page .faq details p {
+    margin-right: 18px;
+    margin-left: 18px;
+    padding-right: 0;
+  }
+
+  .financing-page .fin-cta .button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .financing-page .calculator input[type="range"],
+  .financing-page .service-card__media img {
+    transition: none;
+  }
+}

--- a/financing/index.html
+++ b/financing/index.html
@@ -1,21 +1,27 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <link rel="icon" type="image/png" sizes="512x512" href="/zenith-favicon-v3.png?v=3">
   <link rel="apple-touch-icon" href="/zenith-favicon-v3.png?v=3">
-  <title>Roof Financing in San Diego, North County & Temecula | Zenith Roofing</title>
+  <title>Roof Financing | San Diego, North County &amp; Temecula | Zenith</title>
   <meta name="description" content="Explore roof financing with 0% APR for 3 months available to qualifying customers through Wisetack. Estimate payments for $500–$25,000 roofing projects in San Diego, North County and Temecula.">
   <link rel="canonical" href="https://zenithroofingservices.com/financing/">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Roof Financing in San Diego, North County & Temecula | Zenith Roofing">
+  <meta property="og:title" content="Roof Financing in San Diego, North County &amp; Temecula | Zenith Roofing">
   <meta property="og:description" content="0% APR for 3 months may be available to qualifying roofing customers through Wisetack. Check options without affecting your credit score.">
   <meta property="og:url" content="https://zenithroofingservices.com/financing/">
   <meta property="og:image" content="https://zenithroofingservices.com/zenith-favicon-v3.png">
-  <link rel="stylesheet" href="/css/base.css">
-  <link rel="stylesheet" href="/css/header.css">
-  <link rel="stylesheet" href="/css/footer.css">
+  <link rel="preload" as="image" type="image/webp"
+        href="/images/modern-tile-roof-1600.webp"
+        imagesrcset="/images/modern-tile-roof-640.webp 640w,
+                     /images/modern-tile-roof-960.webp 960w,
+                     /images/modern-tile-roof-1280.webp 1280w,
+                     /images/modern-tile-roof-1600.webp 1600w"
+        imagesizes="100vw">
+  <link rel="stylesheet" href="/css/zenith-premium-exact.css?v=exact-premium-3">
+  <link rel="stylesheet" href="/css/financing-premium.css?v=1">
   <script async src="https://www.googletagmanager.com/gtag/js?id=AW-574510700"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
@@ -95,135 +101,87 @@
     ]
   }
   </script>
-  <style>
-    :root{--navy:#072e59;--navy2:#123f6d;--orange:#ff9418;--ink:#11233b;--muted:#5f6f84;--pale:#f4f7fb}
-    *{box-sizing:border-box}
-    body{margin:0;color:var(--ink);font-family:system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif;line-height:1.6;background:#fff}
-    .fin-hero{padding:118px 20px 82px;background:linear-gradient(125deg,rgba(7,46,89,.98),rgba(18,63,109,.94));color:#fff;text-align:center}
-    .fin-wrap{width:min(1120px,calc(100% - 40px));margin:auto}
-    .eyebrow{display:inline-block;margin-bottom:12px;color:#ffd49d;font-weight:800;letter-spacing:.08em;text-transform:uppercase}
-    .fin-hero h1{max-width:900px;margin:0 auto 18px;font-size:clamp(2.1rem,5vw,4rem);line-height:1.08}
-    .fin-hero p{max-width:760px;margin:0 auto 28px;font-size:clamp(1.05rem,2vw,1.3rem);color:#e8f0f8}
-    .fin-actions{display:flex;justify-content:center;gap:14px;flex-wrap:wrap}
-    .fin-btn{display:inline-flex;align-items:center;justify-content:center;min-height:54px;padding:14px 24px;border-radius:9px;font-weight:800;text-decoration:none}
-    .fin-btn-primary{background:var(--orange);color:#102b4b;box-shadow:0 12px 26px rgba(0,0,0,.22)}
-    .fin-btn-secondary{border:2px solid #fff;color:#fff}
-    .fin-trust{margin-top:24px;font-size:.93rem;color:#dce8f4}
-    .fin-section{padding:72px 0}
-    .fin-section.alt{background:var(--pale)}
-    .fin-section h2{font-size:clamp(1.7rem,3vw,2.5rem);line-height:1.2;color:var(--navy);margin:0 0 16px}
-    .lead{max-width:800px;font-size:1.12rem;color:var(--muted)}
-    .benefits{display:grid;grid-template-columns:repeat(3,1fr);gap:22px;margin-top:34px}
-    .benefit,.step,.service-card{padding:26px;background:#fff;border:1px solid #dfe6ee;border-radius:14px;box-shadow:0 9px 25px rgba(7,46,89,.07)}
-    .benefit strong{display:block;color:var(--navy);font-size:1.15rem;margin-bottom:6px}
-    .check{display:grid;place-items:center;width:42px;height:42px;margin-bottom:14px;border-radius:50%;background:#e8f8f2;color:#087c55;font-size:1.35rem;font-weight:900}
-    .steps{display:grid;grid-template-columns:repeat(3,1fr);gap:22px;margin-top:30px}
-    .step-num{display:grid;place-items:center;width:40px;height:40px;border-radius:50%;background:var(--orange);color:#102b4b;font-weight:900;margin-bottom:14px}
-    .services{display:grid;grid-template-columns:repeat(2,1fr);gap:18px;margin-top:28px}
-    .service-card h3{margin:0 0 8px;color:var(--navy)}
-    .faq{max-width:900px}
-    .faq details{background:#fff;border:1px solid #dfe6ee;border-radius:10px;margin:12px 0;padding:0 20px}
-    .faq summary{cursor:pointer;font-weight:800;color:var(--navy);padding:19px 0}
-    .faq details p{margin:0 0 20px;color:var(--muted)}
-    .calc-layout{display:grid;grid-template-columns:minmax(0,.8fr) minmax(460px,1.2fr);gap:42px;align-items:start}
-    .calculator{background:#fff;border:1px solid #d7e0ea;border-radius:16px;padding:28px;box-shadow:0 12px 34px rgba(7,46,89,.1)}
-    .calculator label{display:block;font-weight:800;color:var(--navy);margin-bottom:8px}
-    .amount-row{display:grid;grid-template-columns:1fr 150px;gap:18px;align-items:center}
-    .calculator input[type="range"]{width:100%;accent-color:var(--orange)}
-    .calculator input[type="number"]{width:100%;padding:12px;border:2px solid #ccd7e4;border-radius:8px;font-size:1.05rem}
-    .range-labels{display:flex;justify-content:space-between;color:var(--muted);font-size:.85rem;margin:5px 0 18px}
-    .calc-highlight{padding:16px;margin:18px 0;background:#eef6ff;border-left:5px solid var(--orange);color:var(--navy);font-weight:750}
-    .calc-table-wrap{overflow-x:auto}
-    .calc-table{width:100%;border-collapse:collapse;font-size:.93rem}
-    .calc-table th,.calc-table td{padding:11px 9px;border-bottom:1px solid #dbe3ec;text-align:right;white-space:nowrap}
-    .calc-table th:first-child,.calc-table td:first-child{text-align:left}
-    .calc-table th{background:#eaf6f8;color:var(--navy);font-size:.78rem;text-transform:uppercase;letter-spacing:.03em}
-    .calc-disclaimer{font-size:.78rem;color:var(--muted);line-height:1.5;margin:16px 0 0}
-    .local-copy{margin-top:34px;padding:26px;background:#fff;border:1px solid #dfe6ee;border-radius:14px}
-    .local-copy h3{color:var(--navy);margin-top:0}
-    .fin-cta{padding:66px 20px;text-align:center;background:var(--navy);color:#fff}
-    .fin-cta h2{color:#fff}
-    .disclosure{max-width:950px;margin:30px auto 0;font-size:.78rem;line-height:1.55;color:#cbd8e5;text-align:left}
-    .fin-note{padding:18px 20px;border-left:5px solid var(--orange);background:#fff7ea;color:#44331c;margin-top:28px}
-    .zero-apr-banner{margin-top:30px;padding:26px;border:2px solid var(--orange);border-radius:14px;background:linear-gradient(110deg,#fff7ea,#fff);box-shadow:0 10px 28px rgba(7,46,89,.08);text-align:center}
-    .zero-apr-banner strong{display:block;color:var(--navy);font-size:clamp(1.55rem,3vw,2.25rem);line-height:1.15;margin-bottom:8px}
-    .zero-apr-banner p{margin:0 auto 18px;max-width:760px;color:#44556b}
-    .internal-links{display:flex;gap:18px;flex-wrap:wrap;margin-top:22px}
-    .internal-links a{font-weight:750;color:#075fa9}
-    .finance-lead-layout{display:grid;grid-template-columns:minmax(0,.72fr) minmax(520px,1.28fr);gap:42px;align-items:start}
-    .finance-form-card{background:#fff;border:1px solid #d7e0ea;border-radius:16px;padding:30px;box-shadow:0 12px 34px rgba(7,46,89,.1)}
-    .finance-form-card h3{margin:0 0 6px;color:var(--navy);font-size:1.45rem}
-    .finance-form-card>p{margin:0 0 22px;color:var(--muted)}
-    .finance-form-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-    .finance-form-field{display:flex;flex-direction:column;gap:6px}
-    .finance-form-field.full{grid-column:1/-1}
-    .finance-form-field label{font-weight:750;color:var(--navy)}
-    .finance-form-field input,.finance-form-field select,.finance-form-field textarea{width:100%;padding:13px 14px;border:2px solid #ccd7e4;border-radius:8px;background:#fff;color:var(--ink);font:inherit}
-    .finance-form-field textarea{min-height:118px;resize:vertical}
-    .finance-form-field input:focus,.finance-form-field select:focus,.finance-form-field textarea:focus{outline:3px solid rgba(255,148,24,.22);border-color:var(--orange)}
-    .finance-form.was-validated :invalid{border-color:#c62828;background:#fff7f7;box-shadow:0 0 0 2px rgba(198,40,40,.12)}
-    .finance-form-status{min-height:24px;margin:14px 0 0;font-weight:750}
-    .finance-form-status.error{color:#a61b1b}
-    .finance-form-status.success{color:#087c55}
-    .finance-form-submit{width:100%;border:0;cursor:pointer;margin-top:16px}
-    .finance-form-submit:disabled{opacity:.65;cursor:wait}
-    .form-privacy{font-size:.78rem;color:var(--muted);line-height:1.5;margin:12px 0 0}
-    .finance-interest-note{padding:18px;border-left:5px solid var(--orange);background:#fff7ea;color:#44331c;margin-top:22px}
-    @media(max-width:800px){.benefits,.steps,.services,.calc-layout,.finance-lead-layout{grid-template-columns:1fr}.calc-layout,.finance-lead-layout{gap:26px}.calculator,.finance-form-card{padding:20px}.amount-row,.finance-form-grid{grid-template-columns:1fr}.finance-form-field.full{grid-column:auto}.fin-hero{padding-top:92px}.fin-wrap{width:min(100% - 28px,1120px)}}
-  </style>
-  <link rel="stylesheet" href="/css/landing-theme-preview.css?v=sitewide-2">
 </head>
 <body>
   <section data-include="/components/header-section.html"></section>
-  <main>
-    <section class="fin-hero">
-      <div class="fin-wrap">
-        <span class="eyebrow">Roofing payment options</span>
-        <h1>Roof Financing in San Diego, North County &amp; Temecula</h1>
-        <p>Zenith Roofing Services offers eligible homeowners convenient financing options through Wisetack lending partners for qualifying roofing projects.</p>
-        <div class="fin-actions">
-          <a class="fin-btn fin-btn-primary wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Check My Financing Options</a>
-          <a class="fin-btn fin-btn-secondary" href="#payment-calculator">Estimate Monthly Payments</a>
-          <a class="fin-btn fin-btn-secondary" href="#financing-estimate">Request a Roofing Estimate</a>
+  <main id="main-content" class="premium-page financing-page">
+    <section class="interior-hero financing-hero">
+      <img src="/images/modern-tile-roof-1600.webp"
+           srcset="/images/modern-tile-roof-640.webp 640w,
+                   /images/modern-tile-roof-960.webp 960w,
+                   /images/modern-tile-roof-1280.webp 1280w,
+                   /images/modern-tile-roof-1600.webp 1600w"
+           sizes="100vw"
+           alt="Completed Southern California tile roof by Zenith Roofing Services"
+           width="1600" height="900" fetchpriority="high">
+      <span class="interior-hero__shade" aria-hidden="true"></span>
+      <div class="shell interior-hero__content financing-hero__content">
+        <div class="financing-hero__copy">
+          <span class="eyebrow eyebrow--light">Roofing payment options</span>
+          <h1>Roof financing in San Diego, North County &amp; Temecula.</h1>
+          <p>Eligible property owners can explore convenient financing options through Wisetack lending partners for qualifying roofing projects.</p>
+          <div class="interior-hero__actions">
+            <a class="button button--orange wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Check My Financing Options <span aria-hidden="true">→</span></a>
+            <a class="button button--glass" href="#payment-calculator">Estimate Monthly Payments</a>
+            <a class="button button--glass" href="#financing-estimate">Request a Roofing Estimate</a>
+          </div>
+          <p class="financing-hero__fine">Checking eligibility does not affect your credit score. Financing is subject to credit approval.</p>
         </div>
-        <div class="fin-trust"><strong>0% APR for 3 months may be available to qualifying customers.</strong> Checking eligibility does not affect your credit score. Financing is subject to credit approval.</div>
+        <aside class="financing-offer" aria-label="Featured financing option">
+          <span class="financing-offer__label">For qualifying customers</span>
+          <strong><span>0%</span> APR</strong>
+          <h2>for 3 months*</h2>
+          <p>May be available through Wisetack lending partners for eligible roofing projects.</p>
+          <a class="text-link wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">View available options <span aria-hidden="true">→</span></a>
+        </aside>
       </div>
     </section>
 
-    <section class="fin-section">
-      <div class="fin-wrap">
-        <h2>Make a necessary roofing project easier to plan</h2>
-        <p class="lead">A roof replacement or major repair can be difficult to fit into one payment. Financing may let an eligible customer move forward with necessary work while selecting a payment option that better fits the household budget.</p>
+    <section class="interior-trust" aria-label="Financing highlights">
+      <div class="shell interior-trust__grid">
+        <span><b>Soft credit inquiry</b><small>No score impact to check eligibility</small></span>
+        <span><b>$500–$25,000 projects</b><small>Use our planning calculator</small></span>
+        <span><b>Clear terms first</b><small>Review options before deciding</small></span>
+        <span><b>Secure application</b><small>Completed through Wisetack</small></span>
+      </div>
+    </section>
+
+    <section class="fin-section fin-intro">
+      <div class="shell">
+        <div class="fin-section-heading">
+          <div>
+            <span class="eyebrow">Flexible project planning</span>
+            <h2>Make necessary roofing work easier to plan.</h2>
+          </div>
+          <p>A roof replacement or major repair can be difficult to fit into one payment. Financing may help an eligible property owner move forward while selecting an option that better fits the project budget.</p>
+        </div>
         <div class="benefits">
-          <article class="benefit"><span class="check">✓</span><strong>No credit impact to check eligibility</strong><span>Wisetack uses a soft credit inquiry when you check available options.</span></article>
-          <article class="benefit"><span class="check">✓</span><strong>Clear options before you commit</strong><span>Review available rates, terms and estimated payments before choosing whether to proceed.</span></article>
-          <article class="benefit"><span class="check">✓</span><strong>No hidden fees</strong><span>Wisetack presents lending terms clearly. Your individual offer depends on credit approval and eligibility.</span></article>
+          <article class="benefit"><span class="check">✓</span><strong>No credit impact to check eligibility</strong><p>Wisetack uses a soft credit inquiry when you check available options.</p></article>
+          <article class="benefit"><span class="check">✓</span><strong>Clear options before you commit</strong><p>Review available rates, terms and estimated payments before choosing whether to proceed.</p></article>
+          <article class="benefit"><span class="check">✓</span><strong>No hidden fees</strong><p>Wisetack presents lending terms clearly. Your individual offer depends on credit approval and eligibility.</p></article>
         </div>
-        <div class="fin-note"><strong>Prequalification is not a roofing estimate.</strong> Start with a Zenith roof inspection or estimate so the project scope and price can be confirmed.</div>
-        <div class="zero-apr-banner">
-          <strong>0% APR for 3 Months*</strong>
-          <p>Available to qualifying customers through Wisetack lending partners for eligible roofing projects. Check your options without affecting your credit score.</p>
-          <a class="fin-btn fin-btn-primary wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Check My Financing Options</a>
-        </div>
+        <div class="fin-note"><span aria-hidden="true">i</span><p><strong>Prequalification is not a roofing estimate.</strong> Start with a Zenith roof inspection or estimate so the project scope and price can be confirmed.</p></div>
       </div>
     </section>
 
-
-    <section class="fin-section alt" id="payment-calculator">
-      <div class="fin-wrap calc-layout">
-        <div>
-          <span class="eyebrow" style="color:#9a5600">Planning tool</span>
-          <h2>Estimate roofing payments from $500 to $25,000</h2>
-          <p class="lead">Choose a roofing project amount to see illustrative monthly-payment examples. This calculator helps homeowners in San Diego County, North County, Temecula, Murrieta, Wildomar and nearby communities plan before requesting an estimate or checking eligibility.</p>
-          <p>The APRs and terms shown are examples based on the options currently displayed in Zenith Roofing’s Wisetack merchant calculator. They are not a loan offer, approval, or guarantee. Your actual options depend on credit approval, the requested amount and participating lending partners.</p>
-          <a class="fin-btn fin-btn-primary wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Check Actual Eligibility</a>
+    <section class="fin-section fin-section--mist" id="payment-calculator">
+      <div class="shell calc-layout">
+        <div class="calc-copy">
+          <span class="eyebrow">Planning tool</span>
+          <h2>Estimate roofing payments from $500 to $25,000.</h2>
+          <p class="lead">Choose a roofing project amount to see illustrative monthly-payment examples. This calculator helps property owners in San Diego County, North County, Temecula, Murrieta, Wildomar and nearby communities plan before requesting an estimate or checking eligibility.</p>
+          <p>The APRs and terms shown are examples based on the options currently displayed in Zenith Roofing’s Wisetack merchant calculator. They are not a loan offer, approval or guarantee. Your actual options depend on credit approval, the requested amount and participating lending partners.</p>
+          <a class="button button--navy wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Check Actual Eligibility <span aria-hidden="true">→</span></a>
         </div>
-        <div class="calculator" aria-labelledby="calculator-title">
-          <h3 id="calculator-title">Roof financing payment estimator</h3>
+        <section class="calculator" aria-labelledby="calculator-title">
+          <div class="calculator__heading">
+            <span>Payment planning</span>
+            <h3 id="calculator-title">Roof financing payment estimator</h3>
+          </div>
           <label for="project-amount">Estimated roofing project amount</label>
           <div class="amount-row">
             <input id="project-amount-range" type="range" min="500" max="25000" step="500" value="10000" aria-label="Estimated roofing project amount">
-            <input id="project-amount" type="number" min="500" max="25000" step="500" value="10000" inputmode="numeric" aria-label="Roofing project amount in dollars">
+            <span class="amount-input"><b>$</b><input id="project-amount" type="number" min="500" max="25000" step="500" value="10000" inputmode="numeric" aria-label="Roofing project amount in dollars"></span>
           </div>
           <div class="range-labels"><span>$500</span><span>$25,000</span></div>
           <div class="calc-highlight" id="calc-highlight" aria-live="polite"></div>
@@ -234,40 +192,40 @@
             </table>
           </div>
           <p class="calc-disclaimer">Illustrative estimates only. Not all terms are available for every amount or applicant. Financing is subject to credit approval. Checking eligibility does not affect your credit score; accepting an offer may involve additional credit review.</p>
-        </div>
+        </section>
       </div>
     </section>
 
-
-    <section class="fin-section" id="financing-estimate">
-      <div class="fin-wrap finance-lead-layout">
-        <div>
-          <span class="eyebrow" style="color:#9a5600">Estimate with payment options</span>
-          <h2>Request a roofing estimate and explore payment options</h2>
+    <section class="fin-section fin-estimate" id="financing-estimate">
+      <div class="shell finance-lead-layout">
+        <div class="finance-lead-copy">
+          <span class="eyebrow">Estimate with payment options</span>
+          <h2>Request a roofing estimate and explore payment options.</h2>
           <p class="lead">Use this form when you need a roofing estimate and would also like to discuss flexible payment options. Your request will go directly into Zenith’s lead system with that preference clearly noted.</p>
-          <div class="finance-interest-note"><strong>Your request for payment options is added automatically.</strong> You do not need to repeat it in the project description. This form requests a roofing estimate; it does not submit a credit application or guarantee financing approval.</div>
-          <div class="internal-links">
-            <a class="wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Prefer to check eligibility first? Open Wisetack</a>
-          </div>
+          <div class="finance-interest-note"><span aria-hidden="true">✓</span><p><strong>Your request for payment options is added automatically.</strong> You do not need to repeat it in the project description. This form requests a roofing estimate; it does not submit a credit application or guarantee financing approval.</p></div>
+          <a class="finance-inline-link wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Prefer to check eligibility first? Open Wisetack <span aria-hidden="true">→</span></a>
         </div>
         <div class="finance-form-card">
-          <h3>Roofing estimate and payment options</h3>
-          <p>Required fields are marked with an asterisk. Your California address and contact details will populate the matching JobNimbus fields.</p>
+          <div class="finance-form-card__head">
+            <span>Secure estimate request</span>
+            <h3>Roofing estimate and payment options</h3>
+            <p>Required fields are marked with an asterisk. Your California address and contact details will populate the matching JobNimbus fields.</p>
+          </div>
           <form id="financing-lead-form" class="finance-form" novalidate>
             <div class="finance-form-grid">
-              <div class="finance-form-field"><label for="fin-first-name">First name *</label><input id="fin-first-name" name="first_name" autocomplete="given-name" required></div>
-              <div class="finance-form-field"><label for="fin-last-name">Last name *</label><input id="fin-last-name" name="last_name" autocomplete="family-name" required></div>
+              <div class="finance-form-field"><label for="fin-first-name">First name *</label><input id="fin-first-name" name="first_name" type="text" autocomplete="given-name" required></div>
+              <div class="finance-form-field"><label for="fin-last-name">Last name *</label><input id="fin-last-name" name="last_name" type="text" autocomplete="family-name" required></div>
               <div class="finance-form-field"><label for="fin-phone">Phone number *</label><input id="fin-phone" name="phone" type="tel" autocomplete="tel" inputmode="tel" placeholder="(760) 555-1234" pattern="\([0-9]{3}\) [0-9]{3}-[0-9]{4}" maxlength="18" required></div>
               <div class="finance-form-field"><label for="fin-email">Email address *</label><input id="fin-email" name="email" type="email" autocomplete="email" required></div>
-              <div class="finance-form-field full"><label for="fin-street">Street address *</label><input id="fin-street" name="street_address" autocomplete="street-address" required></div>
-              <div class="finance-form-field"><label for="fin-city">City *</label><input id="fin-city" name="city" autocomplete="address-level2" required></div>
-              <div class="finance-form-field"><label for="fin-zip">California ZIP code *</label><input id="fin-zip" name="zip" autocomplete="postal-code" inputmode="numeric" pattern="9[0-6][0-9]{3}" maxlength="5" required></div>
+              <div class="finance-form-field full"><label for="fin-street">Street address *</label><input id="fin-street" name="street_address" type="text" autocomplete="address-line1" required></div>
+              <div class="finance-form-field"><label for="fin-city">City *</label><input id="fin-city" name="city" type="text" autocomplete="address-level2" required></div>
+              <div class="finance-form-field"><label for="fin-zip">California ZIP code *</label><input id="fin-zip" name="zip" type="text" autocomplete="postal-code" inputmode="numeric" pattern="9[0-6][0-9]{3}" maxlength="5" required></div>
               <div class="finance-form-field full"><label for="fin-service">Roofing service *</label><select id="fin-service" name="service_type" required><option value="">Choose a service</option><option>Roof Replacement</option><option>Roof Repair</option><option>Tile Lift and Relay</option><option>Flat or Low-Slope Roofing</option><option>Roof Inspection</option><option>Not Sure Yet</option></select></div>
               <div class="finance-form-field full"><label for="fin-description">Tell us about the roof or project *</label><textarea id="fin-description" name="description" placeholder="Leaks, roof type, approximate age, timing, or anything else we should know" required></textarea></div>
             </div>
             <input type="hidden" name="state" value="CA">
-            <div id="financing-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5" style="margin-top:18px"></div>
-            <button class="fin-btn fin-btn-primary finance-form-submit" type="submit">Request My Roofing Estimate</button>
+            <div id="financing-recaptcha" class="finance-recaptcha" data-sitekey="6LfD_borAAAAAFEtGO9x__VXAbvSjDYRiVaVpea5"></div>
+            <button class="button button--orange button--full finance-form-submit" type="submit">Request My Roofing Estimate <span aria-hidden="true">→</span></button>
             <div id="financing-form-status" class="finance-form-status" role="status" aria-live="polite"></div>
             <p class="form-privacy">Your information is used to respond to your roofing request. Submitting this form does not apply for credit. Financing applications are completed securely through Wisetack.</p>
           </form>
@@ -275,60 +233,84 @@
       </div>
     </section>
 
-    <section class="fin-section alt">
-      <div class="fin-wrap">
-        <h2>How roof financing works</h2>
+    <section class="fin-section fin-process">
+      <div class="shell">
+        <div class="fin-section-heading fin-section-heading--light">
+          <div><span class="eyebrow eyebrow--light">A clear next step</span><h2>How roof financing works.</h2></div>
+          <p>Explore your potential options first, then keep the financing decision separate from Zenith’s detailed roofing scope.</p>
+        </div>
         <div class="steps">
-          <article class="step"><span class="step-num">1</span><h3>Check eligibility</h3><p>Use Zenith's secure Wisetack link to enter your mobile number and view whether options may be available.</p></article>
-          <article class="step"><span class="step-num">2</span><h3>Review your options</h3><p>Qualified applicants can review available APRs, terms and estimated payments. Checking options does not obligate you to proceed.</p></article>
-          <article class="step"><span class="step-num">3</span><h3>Approve the roofing scope</h3><p>Zenith confirms the roofing proposal separately. If you choose financing, the selected option is completed through the applicable lending partner.</p></article>
+          <article class="step"><span class="step-num">01</span><h3>Check eligibility</h3><p>Use Zenith's secure Wisetack link to enter your mobile number and view whether options may be available.</p></article>
+          <article class="step"><span class="step-num">02</span><h3>Review your options</h3><p>Qualified applicants can review available APRs, terms and estimated payments. Checking options does not obligate you to proceed.</p></article>
+          <article class="step"><span class="step-num">03</span><h3>Approve the roofing scope</h3><p>Zenith confirms the roofing proposal separately. If you choose financing, the selected option is completed through the applicable lending partner.</p></article>
         </div>
       </div>
     </section>
 
-    <section class="fin-section">
-      <div class="fin-wrap">
-        <h2>Roofing projects that may qualify</h2>
-        <p class="lead">Eligibility depends on the customer, project amount and lending partner. Zenith can prepare a detailed proposal for the roofing work you need.</p>
-        <div class="services">
-          <article class="service-card"><h3>Roof replacement financing</h3><p>Payment options may be available for asphalt shingle, tile, TPO, torch-down and other complete roof systems.</p></article>
-          <article class="service-card"><h3>Roof repair financing</h3><p>Larger leak repairs, damaged roofing, decking corrections and related scope may qualify when program requirements are met.</p></article>
-          <article class="service-card"><h3>Residential roofing</h3><p>Financing may help eligible homeowners plan necessary roof work without delaying a project solely because of the upfront cost.</p></article>
-          <article class="service-card"><h3>Energy-conscious roof upgrades</h3><p>Ask Zenith about available cool-roof shingles, reflective membranes, insulation and coating options appropriate for your property.</p></article>
+    <section class="fin-section fin-projects">
+      <div class="shell">
+        <div class="fin-section-heading">
+          <div><span class="eyebrow">Eligible project types</span><h2>Roofing projects that may qualify.</h2></div>
+          <p>Eligibility depends on the customer, project amount and lending partner. Zenith can prepare a detailed proposal for the roofing work you need.</p>
         </div>
+        <div class="services">
+          <article class="service-card"><div class="service-card__media"><img src="/images/modern-tile-roof-1280.webp" alt="Completed tile roof replacement" width="720" height="520" loading="lazy"><span>Replacement</span></div><div class="service-card__body"><h3>Roof replacement financing</h3><p>Payment options may be available for asphalt shingle, tile, TPO, torch-down and other complete roof systems.</p></div></article>
+          <article class="service-card"><div class="service-card__media"><img src="/images/tile-roof-repair/tile-roof-chimney-completed-1200.webp" alt="Completed tile roof repair" width="720" height="520" loading="lazy"><span>Repair</span></div><div class="service-card__body"><h3>Roof repair financing</h3><p>Larger leak repairs, damaged roofing, decking corrections and related scope may qualify when program requirements are met.</p></div></article>
+          <article class="service-card"><div class="service-card__media"><img src="/images/roof-tune-up/commercial-roof-tune-up-overview-1200.webp" alt="Commercial flat roof service" width="720" height="520" loading="lazy"><span>Property</span></div><div class="service-card__body"><h3>Property roofing projects</h3><p>Financing may help eligible property owners plan necessary roof work without delaying a project solely because of the upfront cost.</p></div></article>
+          <article class="service-card"><div class="service-card__media"><img src="/images/flat-roof-repair/completed-bur-roof-repair-1200.webp" alt="Completed energy-conscious flat roofing work" width="720" height="520" loading="lazy"><span>Efficiency</span></div><div class="service-card__body"><h3>Energy-conscious roof upgrades</h3><p>Ask Zenith about available cool-roof shingles, reflective membranes, insulation and coating options appropriate for your property.</p></div></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="fin-section fin-local">
+      <div class="shell fin-local__layout">
         <div class="local-copy">
-          <h3>Local roof financing information for San Diego and Southwest Riverside County</h3>
+          <span class="eyebrow">Local financing guidance</span>
+          <h2>San Diego County &amp; Southwest Riverside County.</h2>
           <p>Zenith Roofing Services provides roof inspections, repair proposals and replacement estimates throughout Escondido, San Marcos, Vista, Oceanside, Carlsbad, Encinitas, Poway, Rancho Bernardo and greater San Diego County. We also serve Temecula, Murrieta, Wildomar and surrounding Southwest Riverside County communities when the location and roofing scope fit our service area.</p>
           <p>Customers may explore payment options for qualifying asphalt-shingle, tile, TPO, torch-down, low-slope and coating projects. Financing does not replace a roofing evaluation: Zenith first confirms the roof condition, recommended system, written scope and project price.</p>
+          <div class="internal-links">
+            <a href="/roof-replacement">Roof replacement estimate <span>↗</span></a>
+            <a href="/services/roof-replacement/">Roof replacement services <span>↗</span></a>
+            <a href="/services/residential/tpo/">Residential TPO roofing <span>↗</span></a>
+            <a href="/contact/">Contact Zenith Roofing <span>↗</span></a>
+          </div>
         </div>
-        <div class="internal-links">
-          <a href="/roof-replacement">Roof replacement estimate</a>
-          <a href="/services/roof-replacement/">Roof replacement services</a>
-          <a href="/services/residential/tpo/">Residential TPO roofing</a>
-          <a href="/contact/">Contact Zenith Roofing</a>
-        </div>
+        <aside class="local-finance-card" aria-label="Local roofing estimate next step">
+          <span class="local-finance-card__icon" aria-hidden="true">⌖</span>
+          <small>Southern California</small>
+          <strong>Local roofing. Flexible planning.</strong>
+          <p>Start with a clear roofing estimate, then review any financing options that may fit your project.</p>
+          <a class="button button--orange button--full" href="#financing-estimate">Request an Estimate <span aria-hidden="true">→</span></a>
+        </aside>
       </div>
     </section>
 
-    <section class="fin-section alt">
-      <div class="fin-wrap faq">
-        <h2>Roof financing questions</h2>
-        <details><summary>Does Zenith Roofing offer 0% APR financing for 3 months?</summary><p>A 3-month 0% APR option may be available to qualifying customers through Wisetack lending partners. Financing is subject to credit approval, and your available terms depend on the requested amount and creditworthiness.</p></details>
-        <details><summary>Does checking eligibility affect my credit score?</summary><p>No. Wisetack states that checking available financing options uses a soft credit inquiry and does not affect your credit score. If you accept an offer, additional credit review may apply.</p></details>
-        <details><summary>Can I estimate payments for projects from $500 to $25,000?</summary><p>Yes. Zenith’s planning calculator accepts amounts from $500 through $25,000 and displays illustrative payment examples. It does not determine eligibility or guarantee that a particular amount, APR or term will be offered.</p></details>
-        <details><summary>Can I finance a new roof?</summary><p>Eligible customers may receive options for qualifying roof replacements and other roofing projects. Available amounts, APRs and terms depend on creditworthiness, the requested amount and participating lending partners.</p></details>
-        <details><summary>Does Zenith offer roofing payment plans directly?</summary><p>Financing options are provided through Wisetack lending partners, not directly by Zenith Roofing Services. Zenith provides the roofing estimate, contract and installation scope.</p></details>
-        <details><summary>Can I check financing before receiving an estimate?</summary><p>You may check eligibility first, but a prequalification is not a final project price. Zenith must inspect or evaluate the roof and prepare the applicable roofing proposal.</p></details>
-        <details><summary>What areas does Zenith serve?</summary><p>Zenith Roofing Services is based in Escondido and serves San Diego County, North County, Temecula, Murrieta, Wildomar, Southwest Riverside County and surrounding Southern California communities. Project availability depends on location and scope.</p></details>
-        <details><summary>What information will I receive?</summary><p>If options are available, Wisetack will show the applicable payment amount, APR and term before you decide whether to proceed. Prequalification estimates are not guaranteed financing offers.</p></details>
+    <section class="fin-section fin-faq-section">
+      <div class="shell faq-layout">
+        <div class="faq-heading">
+          <span class="eyebrow">Straight answers</span>
+          <h2>Roof financing questions.</h2>
+          <p>Understand what prequalification means, what the calculator shows and how financing stays separate from your Zenith roofing proposal.</p>
+          <a class="button button--navy wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Check My Options <span aria-hidden="true">→</span></a>
+        </div>
+        <div class="faq">
+          <details><summary>Does Zenith Roofing offer 0% APR financing for 3 months?<span aria-hidden="true">+</span></summary><p>A 3-month 0% APR option may be available to qualifying customers through Wisetack lending partners. Financing is subject to credit approval, and your available terms depend on the requested amount and creditworthiness.</p></details>
+          <details><summary>Does checking eligibility affect my credit score?<span aria-hidden="true">+</span></summary><p>No. Wisetack states that checking available financing options uses a soft credit inquiry and does not affect your credit score. If you accept an offer, additional credit review may apply.</p></details>
+          <details><summary>Can I estimate payments for projects from $500 to $25,000?<span aria-hidden="true">+</span></summary><p>Yes. Zenith’s planning calculator accepts amounts from $500 through $25,000 and displays illustrative payment examples. It does not determine eligibility or guarantee that a particular amount, APR or term will be offered.</p></details>
+          <details><summary>Can I finance a new roof?<span aria-hidden="true">+</span></summary><p>Eligible customers may receive options for qualifying roof replacements and other roofing projects. Available amounts, APRs and terms depend on creditworthiness, the requested amount and participating lending partners.</p></details>
+          <details><summary>Does Zenith offer roofing payment plans directly?<span aria-hidden="true">+</span></summary><p>Financing options are provided through Wisetack lending partners, not directly by Zenith Roofing Services. Zenith provides the roofing estimate, contract and installation scope.</p></details>
+          <details><summary>Can I check financing before receiving an estimate?<span aria-hidden="true">+</span></summary><p>You may check eligibility first, but a prequalification is not a final project price. Zenith must inspect or evaluate the roof and prepare the applicable roofing proposal.</p></details>
+          <details><summary>What areas does Zenith serve?<span aria-hidden="true">+</span></summary><p>Zenith Roofing Services is based in Escondido and serves San Diego County, North County, Temecula, Murrieta, Wildomar, Southwest Riverside County and surrounding Southern California communities. Project availability depends on location and scope.</p></details>
+          <details><summary>What information will I receive?<span aria-hidden="true">+</span></summary><p>If options are available, Wisetack will show the applicable payment amount, APR and term before you decide whether to proceed. Prequalification estimates are not guaranteed financing offers.</p></details>
+        </div>
       </div>
     </section>
 
     <section class="fin-cta">
-      <div class="fin-wrap">
-        <h2>See whether roofing financing options are available</h2>
-        <p>Checking eligibility takes about a minute and does not affect your credit score.</p>
-        <a class="fin-btn fin-btn-primary wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Prequalify Through Wisetack</a>
+      <div class="shell fin-cta__inner">
+        <div><span class="eyebrow eyebrow--light">See your potential options</span><h2>Plan the roof. Understand the payment.</h2><p>Checking eligibility takes about a minute and does not affect your credit score.</p></div>
+        <a class="button button--orange wisetack-link" href="https://wisetack.us/#/s7e1fo0/prequalify" target="_blank" rel="noopener sponsored">Prequalify Through Wisetack <span aria-hidden="true">→</span></a>
         <p class="disclosure">All financing is subject to credit approval. Your terms may vary. Payment options through Wisetack are provided by its lending partners. Offers may range from 0% to 35.9% APR based on the amount requested and creditworthiness. Not all merchants and lending partners participate in 0% interest programs. State interest-rate caps may apply. Prequalification estimates are not guaranteed offers. Checking eligibility does not affect your credit score; accepting an offer may involve additional credit review.</p>
       </div>
     </section>


### PR DESCRIPTION
## What changed
- Rebuilt `/financing/` in the approved premium Zenith navy/orange design system
- Added an image-led hero, financing proof bar, premium payment calculator, lead-form surface, process cards, project imagery, local service-area content, FAQs, and responsive final CTA
- Added large-screen, tablet, and mobile layouts that retain the permanent mobile Home/Call/Text/Estimate/Menu dock
- Broadened customer-facing language from homeowners to property owners

## Functionality preserved
- Existing Wisetack prequalification URL and click/conversion tracking
- Existing payment calculator IDs, terms, formulas, and live results
- Existing JobNimbus lead endpoint and payload
- Existing phone/ZIP validation, reCAPTCHA, form status, and analytics events
- Existing financing disclosures, FAQ schema, SEO content, and internal links

## QA
- `html-validate financing/index.html`
- `git diff --check`
- All functional inline scripts compile successfully
- Functional script blocks verified byte-for-byte unchanged from `main`
- All required form/calculator/tracking hooks verified present