### PR TITLE
Match Resources page to premium Zenith design

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,291 +1,210 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- ===== META ===== -->
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <title>Roofing Blog & DIY Guides | Zenith Roofing Services</title>
-  <meta name="description" content="Practical roofing tips, DIY checklists, and repair stories from a San Diego roofer. Learn about CDX vs OSB, peel-and-stick vs felt, TPO vs torch, ponding water, wind claims, and when to repair or replace." />
-  <link rel="canonical" href="https://zenithroofingservices.com/blog/" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>Roofing Resources &amp; Guides | Zenith Roofing Services</title>
+  <meta name="description" content="Practical roofing tips, checklists and repair stories from a licensed San Diego roofer. Learn about roof decks, underlayment, flat roofs, inspections, leaks and replacement decisions.">
+  <link rel="canonical" href="https://zenithroofingservices.com/blog/">
+  <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Roofing Resources &amp; Guides | Zenith Roofing Services">
+  <meta property="og:description" content="Straightforward roofing guidance from real Southern California field experience.">
+  <meta property="og:url" content="https://zenithroofingservices.com/blog/">
+  <meta property="og:image" content="https://zenithroofingservices.com/images/modern-tile-roof-1600.webp">
 
-  <!-- ===== SITE CSS (already in your project) ===== -->
-  <link rel="stylesheet" href="/css/header.css" />
-  <link rel="stylesheet" href="/css/base.css" />
-  <link rel="stylesheet" href="/css/ui.css" />
+  <link rel="preload" as="image" type="image/webp"
+        href="/images/modern-tile-roof-1600.webp"
+        imagesrcset="/images/modern-tile-roof-640.webp 640w,
+                     /images/modern-tile-roof-960.webp 960w,
+                     /images/modern-tile-roof-1280.webp 1280w,
+                     /images/modern-tile-roof-1600.webp 1600w"
+        imagesizes="100vw">
+  <link rel="stylesheet" href="/css/zenith-premium-exact.css?v=exact-premium-3">
+  <link rel="stylesheet" href="/css/blog-premium.css?v=1">
 
-  <!-- ===== Minimal page-scoped helpers (safe) ===== -->
-  <style>
-    /* Layout shells that rely on your ui.css tokens */
-    .blog-hero{ padding:var(--space-xl, 3rem) var(--space-m, 1.25rem); background:var(--surface-2, #0f172a); color:#fff; text-align:center; }
-    .blog-hero h1{ font-size:clamp(1.8rem, 3.5vw, 2.6rem); line-height:1.1; margin:0 0 .5rem; }
-    .blog-hero p{ max-width:68ch; margin:0 auto; opacity:.9; }
-
-    .section{ padding: min(6vw, 2.5rem) var(--space-m, 1.25rem); }
-    .section h2{ font-size:clamp(1.4rem, 2.6vw, 1.9rem); margin:0 0 .75rem; }
-    .kicker{ font:600 .78rem/1 var(--font, ui-sans-serif); letter-spacing:.08em; text-transform:uppercase; color:var(--muted,#6b7280); margin-bottom:.25rem; }
-
-    .grid{ display:grid; gap:1rem; grid-template-columns:repeat(12, 1fr); }
-    .cards-3 > article{ grid-column: span 12; }
-    @media (min-width: 740px){ .cards-3 > article{ grid-column: span 6; } }
-    @media (min-width: 1024px){ .cards-3 > article{ grid-column: span 4; } }
-
-    article.card{
-      background:var(--ui-bg,#fff); border:1px solid var(--ui-line,#e5e7eb); border-radius: var(--ui-radius,14px);
-      box-shadow: var(--ui-shadow,0 12px 28px rgba(2,12,32,.08)); overflow:hidden; display:flex; flex-direction:column;
-    }
-    .card-media{ aspect-ratio:16/9; background:linear-gradient(180deg,rgba(0,0,0,.08),rgba(0,0,0,.02)); }
-    .card-body{ padding:1rem 1rem 1.1rem; display:flex; flex-direction:column; gap:.5rem; }
-    .tags{ display:flex; gap:.5rem; flex-wrap:wrap; }
-    .tag{ font-size:.75rem; padding:.28rem .5rem; border:1px solid var(--ui-line,#e5e7eb); border-radius:999px; background:#fff; }
-    .card h3{ font-size:1.06rem; margin:.1rem 0; }
-    .card p{ color:var(--muted,#6b7280); margin:0; }
-    .card a{ align-self:flex-start; margin-top:.25rem; text-decoration:none; font-weight:600; }
-    .cta-rail{
-      display:grid; gap:1rem; grid-template-columns:1fr; align-items:center;
-      background:var(--surface-1,#0b1220); color:#fff; border-radius:var(--ui-radius,14px); padding:1.25rem;
-    }
-    @media (min-width: 900px){ .cta-rail{ grid-template-columns:1.5fr .9fr; } }
-    .cta-box{ background:#111827; border:1px solid rgba(255,255,255,.1); border-radius:16px; padding:1rem; }
-    .cta-box p{ margin:.25rem 0 .75rem; opacity:.9; }
-    .btn{
-      display:inline-block; padding:.7rem 1rem; border-radius:999px; border:1px solid #fff; color:#111827; background:#fff; font-weight:700; text-align:center;
-    }
-  </style>
-
-  <!-- ===== JSON-LD: Blog schema (basic) ===== -->
   <script type="application/ld+json">
   {
-    "@context": "https://schema.org",
-    "@type": "Blog",
-    "name": "Zenith Roofing Blog",
-    "url": "https://zenithroofingservices.com/blog/",
-    "description": "DIY roofing guides, repair stories, and professional advice for San Diego & Temecula homeowners and property managers.",
-    "publisher": {
-      "@type": "Organization",
-      "name": "Zenith Roofing Services, Inc."
-    }
+    "@context":"https://schema.org",
+    "@type":"Blog",
+    "name":"Zenith Roofing Resources",
+    "url":"https://zenithroofingservices.com/blog/",
+    "description":"Practical roofing guides, repair stories and professional advice for Southern California property owners and managers.",
+    "publisher":{"@type":"RoofingContractor","name":"Zenith Roofing Services, Inc.","url":"https://zenithroofingservices.com/","telephone":"+1-858-900-6163"},
+    "blogPost":[
+      {"@type":"BlogPosting","headline":"CDX vs. OSB for Roof Decks: Which and Why","url":"https://zenithroofingservices.com/blog/cdx-vs-osb.html"},
+      {"@type":"BlogPosting","headline":"Solar Racking: Why Proper Stanchions and Flashings Beat Bolt-On Shortcuts","url":"https://zenithroofingservices.com/blog/solar-racking-stanchions.html"},
+      {"@type":"BlogPosting","headline":"Peel-and-Stick vs. Felt: Where the Upgrade Pays Off","url":"https://zenithroofingservices.com/blog/peel-and-stick-vs-felt.html"},
+      {"@type":"BlogPosting","headline":"TPO vs Torch-Down: Which System Fits Your Flat Roof?","url":"https://zenithroofingservices.com/blog/tpo-vs-torch.html"},
+      {"@type":"BlogPosting","headline":"Repair or Replace? The 30-Year Reality Check","url":"https://zenithroofingservices.com/blog/repair-vs-replace-30-years.html"},
+      {"@type":"BlogPosting","headline":"San Diego Termites and Roof Leaks: The Hidden Connection","url":"https://zenithroofingservices.com/blog/termites-from-leaks.html"},
+      {"@type":"BlogPosting","headline":"Wood Shakes Under Your Shingles? Check for Skip Sheathing","url":"https://zenithroofingservices.com/blog/wood-shakes-under-shingles.html"},
+      {"@type":"BlogPosting","headline":"Why a Professional Roof Report Beats Guesswork","url":"https://zenithroofingservices.com/blog/why-professional-roof-report.html"},
+      {"@type":"BlogPosting","headline":"Insurance Claims in San Diego: Wind Is the Usual Suspect","url":"https://zenithroofingservices.com/blog/insurance-claims-san-diego-wind.html"},
+      {"@type":"BlogPosting","headline":"Ponding Water: Problem or Just a Flat-Roof Reality?","url":"https://zenithroofingservices.com/blog/ponding-water-crickets-diverters.html"},
+      {"@type":"BlogPosting","headline":"Born and Raised in North County: Why We Treat Every Roof Like Our Own","url":"https://zenithroofingservices.com/blog/bryan-escondido-story.html"},
+      {"@type":"BlogPosting","headline":"Why Manufacturer Specs and Warranty Paths Matter","url":"https://zenithroofingservices.com/blog/why-warranty-matters.html"},
+      {"@type":"BlogPosting","headline":"Repair Stories: Skip Sheathing, Hidden Dry Rot and Smart Sequencing","url":"https://zenithroofingservices.com/blog/repair-stories-skip-sheathing.html"}
+    ]
   }
   </script>
-    <link rel="stylesheet" href="/css/footer.css"/>
-  <link rel="stylesheet" href="/css/landing-theme-preview.css?v=sitewide-2">
 </head>
 <body>
-  <!-- ===== HEADER INCLUDE ===== -->
   <div data-include="/components/header-section.html"></div>
 
-  <main class="page" id="top">
-    <!-- ===== HERO ===== -->
-    <section class="blog-hero">
-      <h1>Zenith Roofing Blog</h1>
-      <p>DIY help, repair know-how, and no-nonsense guidance for San Diego & Temecula. Learn what really matters on a roof—materials, methods, and smart decisions—straight from a licensed C-39 contractor.</p>
-      <!-- ADD HERO IMAGE:
-           Put a wide hero image in /images/blog/hero.webp and set as a background in base.css if you prefer.
-           Example (optional): add a utility class that applies `background-image:url(/images/blog/hero.webp)` -->
+  <main id="main-content" class="premium-page blog-page">
+    <section class="interior-hero blog-hero">
+      <img src="/images/modern-tile-roof-1600.webp"
+           srcset="/images/modern-tile-roof-640.webp 640w,
+                   /images/modern-tile-roof-960.webp 960w,
+                   /images/modern-tile-roof-1280.webp 1280w,
+                   /images/modern-tile-roof-1600.webp 1600w"
+           sizes="100vw"
+           alt="Completed Southern California tile roof documented by Zenith Roofing Services"
+           width="1600" height="900" fetchpriority="high">
+      <span class="interior-hero__shade" aria-hidden="true"></span>
+      <div class="shell interior-hero__content blog-hero__content">
+        <div class="blog-hero__copy">
+          <span class="eyebrow eyebrow--light">Roofing knowledge from the field</span>
+          <h1>Clear roofing answers. Built on real experience.</h1>
+          <p>Practical guides for Southern California property owners, managers and real-estate professionals—written around the materials, failures and decisions we see on actual roofs.</p>
+          <div class="interior-hero__actions">
+            <a class="button button--orange" href="#roofing-guides">Explore Roofing Guides <span aria-hidden="true">↓</span></a>
+            <a class="button button--glass" href="/contact/">Ask Zenith a Question</a>
+          </div>
+        </div>
+        <aside class="blog-hero__edition" aria-label="Zenith resource library summary">
+          <span class="blog-hero__edition-label">The Zenith field library</span>
+          <strong>13</strong>
+          <h2>practical roofing guides</h2>
+          <p>Materials, repairs, inspections, insurance, maintenance and honest project planning.</p>
+          <span class="blog-hero__edition-proof">Licensed C-39 • CSLB #1036112</span>
+        </aside>
+      </div>
     </section>
 
-    <!-- =========================================================
-         70% EDUCATION / DIY — “Know Your Roof” Series
-         ========================================================= -->
-    <section class="section" aria-labelledby="diy-heading">
-      <div class="kicker">DIY & Education</div>
-      <h2 id="diy-heading">Know Your Roof: Quick Wins & Smart Choices</h2>
-      <div class="grid cards-3">
-        <!-- POST 1 -->
-        <article class="card">
-          <!-- COVER IMAGE (RECOMMENDED)
-               Save to: /images/blog/cdx-vs-osb.webp (1200x675)
-               ALT: "CDX vs OSB roof sheathing comparison" -->
-          <div class="card-media" role="img" aria-label="CDX vs OSB roof sheathing comparison"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Materials</span><span class="tag">DIY</span></div>
+    <section class="interior-trust" aria-label="Zenith resource standards">
+      <div class="shell interior-trust__grid">
+        <span><b>Contractor authored</b><small>Guidance grounded in field experience</small></span>
+        <span><b>Southern California specific</b><small>Coastal, inland and valley conditions</small></span>
+        <span><b>Plain-language answers</b><small>Understand the reason behind the work</small></span>
+        <span><b>Real project perspective</b><small>Photos, failures and practical solutions</small></span>
+      </div>
+    </section>
+
+    <section class="blog-feature" aria-labelledby="featured-resource-title">
+      <div class="shell">
+        <div class="blog-section-heading">
+          <div><span class="eyebrow">Featured guide</span><h2 id="featured-resource-title">Start with the roof deck.</h2></div>
+          <p>The roofing system is only as dependable as the surface supporting it. Learn how CDX and OSB behave, where moisture matters and what should be checked before installation.</p>
+        </div>
+        <article class="featured-resource">
+          <a class="featured-resource__media" href="/blog/cdx-vs-osb.html" aria-label="Read CDX vs. OSB for Roof Decks">
+            <img src="/images/clay-tile-roof-repair/clay-tile-lift-deck-replacement-1200.webp" alt="Roof deck exposed during a professional tile roofing project" width="1200" height="900" loading="lazy">
+            <span class="featured-resource__shade" aria-hidden="true"></span>
+            <span class="featured-resource__badge">Materials • Roof Decking</span>
+          </a>
+          <div class="featured-resource__body">
+            <span class="featured-resource__number">01 / Featured</span>
             <h3><a href="/blog/cdx-vs-osb.html">CDX vs. OSB for Roof Decks: Which and Why</a></h3>
             <p>CDX handles moisture cycles better at panel edges; OSB offers uniform density. We break down when each makes sense in San Diego’s coastal climate and what to check in your attic before you decide.</p>
-            <!-- ADD “Read more” content in /blog/cdx-vs-osb.html -->
-          </div>
-        </article>
-
-        <!-- POST 2 -->
-        <article class="card">
-          <!-- COVER: /images/blog/solar-stanchions.webp -->
-          <div class="card-media" role="img" aria-label="Solar racking stanchions flashing on a shingle roof"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Solar</span><span class="tag">Best Practice</span></div>
-            <h3><a href="/blog/solar-racking-stanchions.html">Solar Racking: Why Proper Stanchions & Flashings Beat “Bolt-On” Shortcuts</a></h3>
-            <p>Penetrations are forever. We cover correct stanchion hardware, under-shingle flashing, and sealant stack-ups that keep arrays watertight for the long haul.</p>
-          </div>
-        </article>
-
-        <!-- POST 3 -->
-        <article class="card">
-          <!-- COVER: /images/blog/underlayment-peel-vs-felt.webp -->
-          <div class="card-media" role="img" aria-label="Peel-and-stick underlayment versus traditional felt"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Underlayment</span><span class="tag">Upgrades</span></div>
-            <h3><a href="/blog/peel-and-stick-vs-felt.html">Peel-and-Stick vs. Felt: Where the Upgrade Pays Off</a></h3>
-            <p>Self-adhered membranes shine on low slopes, dead valleys, and eaves. Felt is fine for standard pitches—until wind-driven rain finds a weak spot. Here’s a simple decision tree.</p>
-          </div>
-        </article>
-
-        <!-- POST 4 -->
-        <article class="card">
-          <!-- COVER: /images/blog/tpo-vs-torch.webp -->
-          <div class="card-media" role="img" aria-label="TPO membrane versus torch-down modified bitumen"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Flat Roofs</span><span class="tag">Comparisons</span></div>
-            <h3><a href="/blog/tpo-vs-torch.html">TPO vs Torch-Down: Which System Fits Your Flat Roof?</a></h3>
-            <p>TPO is reflective and seam-welded; torch is rugged and repair-friendly. We outline when to choose each—and what maintenance actually looks like.</p>
-          </div>
-        </article>
-
-        <!-- POST 5 -->
-        <article class="card">
-          <!-- COVER: /images/blog/repair-vs-replace-30years.webp -->
-          <div class="card-media" role="img" aria-label="Aging roof at end-of-life around 30 years"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Decision Guide</span></div>
-            <h3><a href="/blog/repair-vs-replace-30-years.html">Repair or Replace? The 30-Year Reality Check</a></h3>
-            <p>At ~30 years, underlayment and fasteners age out—even if leaks aren’t visible yet. Here’s how to weigh risk of dry rot, hidden deck damage, and the cost curve.</p>
-          </div>
-        </article>
-
-        <!-- POST 6 -->
-        <article class="card">
-          <!-- COVER: /images/blog/termites-from-leaks.webp -->
-          <div class="card-media" role="img" aria-label="Termite damage linked to chronic roof leaks"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Damage</span><span class="tag">San Diego</span></div>
-            <h3><a href="/blog/termites-from-leaks.html">San Diego Termites & Roof Leaks: The Hidden Connection</a></h3>
-            <p>Moisture invites pests. Learn the early signs in fascia and eaves, and why timely leak control protects both structure and resale value.</p>
-          </div>
-        </article>
-
-        <!-- POST 7 -->
-        <article class="card">
-          <!-- COVER: /images/blog/skip-sheathing-check-attic.webp -->
-          <div class="card-media" role="img" aria-label="Attic view showing skip sheathing under old shakes"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Legacy Roofs</span><span class="tag">Inspection</span></div>
-            <h3><a href="/blog/wood-shakes-under-shingles.html">Wood Shakes Under Your Shingles? Check for Skip Sheathing</a></h3>
-            <p>Older homes often have shakes sitting on skip sheathing. If someone later laid shingles over it, ventilation and nailing patterns get tricky—peek in the attic before planning work.</p>
-          </div>
-        </article>
-
-        <!-- POST 8 -->
-        <article class="card">
-          <!-- COVER: /images/blog/why-professional-roof-report.webp -->
-          <div class="card-media" role="img" aria-label="Professional roof inspection report clipboard"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Reports</span><span class="tag">Real Estate</span></div>
-            <h3><a href="/blog/why-professional-roof-report.html">Why a Professional Roof Report Beats Guesswork</a></h3>
-            <p>Good reports document photos, decking, underlayment, penetrations, flashings, and drainage—so you can prioritize repairs, budget realistically, and negotiate with confidence.</p>
-          </div>
-        </article>
-
-        <!-- POST 9 -->
-        <article class="card">
-          <!-- COVER: /images/blog/insurance-wind-claims-sd.webp -->
-          <div class="card-media" role="img" aria-label="Wind-lifted shingles after a storm in San Diego"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Insurance</span><span class="tag">Wind</span></div>
-            <h3><a href="/blog/insurance-claims-san-diego-wind.html">Insurance Claims in San Diego: Wind Is the Usual Suspect</a></h3>
-            <p>From lifted tabs to creased shingles, we outline what’s typically covered, how to document damage, and when to loop a pro in.</p>
-          </div>
-        </article>
-
-        <!-- POST 10 -->
-        <article class="card">
-          <!-- COVER: /images/blog/ponding-water-crickets-diverters.webp -->
-          <div class="card-media" role="img" aria-label="Ponding water near drain and cricket diverters on a flat roof"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Drainage</span><span class="tag">Commercial</span></div>
-            <h3><a href="/blog/ponding-water-crickets-diverters.html">Ponding Water: Problem or Just a Flat-Roof Reality?</a></h3>
-            <p>Sometimes it’s benign; sometimes it’s eating seams. We explain drains, clogs, when crickets/diverters help, and why tapered systems are effective—but pricier.</p>
-          </div>
-        </article>
-
-        <!-- ADD MORE DIY POSTS:
-             Duplicate <article class="card">…</article> and update href, title, summary, tags, and image paths. -->
-      </div>
-    </section>
-
-    <!-- =========================================================
-         20% STORY / HERITAGE — “From Bryan’s Notebook”
-         ========================================================= -->
-    <section class="section" aria-labelledby="story-heading">
-      <div class="kicker">Our Story</div>
-      <h2 id="story-heading">From Bryan’s Notebook: Craft, Roots & Doing It Right</h2>
-      <div class="grid cards-3">
-        <article class="card">
-          <!-- COVER: /images/blog/bryan-escondido.webp -->
-          <div class="card-media" role="img" aria-label="Bryan on a roof in Escondido at sunset"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Heritage</span></div>
-            <h3><a href="/blog/bryan-escondido-story.html">Born & Raised in North County: Why We Treat Every Roof Like Our Own</a></h3>
-            <p>I started on the roof, hands on. The lessons were simple: prep is everything, photos keep everyone honest, and clean-up matters as much as install.</p>
-          </div>
-        </article>
-
-        <article class="card">
-          <!-- COVER: /images/blog/warranty-matters.webp -->
-          <div class="card-media" role="img" aria-label="Close-up of flashed pipe with clean sealant profile"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Craft</span></div>
-            <h3><a href="/blog/why-warranty-matters.html">Why Manufacturer Specs & Warranty Paths Matter</a></h3>
-            <p>It’s not just paper. Following specs on underlayment, flashings, and terminations protects your warranty and your home’s value.</p>
-          </div>
-        </article>
-
-        <article class="card">
-          <!-- COVER: /images/blog/real-repair-stories.webp -->
-          <div class="card-media" role="img" aria-label="Before-and-after repair collage"><!-- image placeholder --></div>
-          <div class="card-body">
-            <div class="tags"><span class="tag">Repair Stories</span></div>
-            <h3><a href="/blog/repair-stories-skip-sheathing.html">Repair Stories: Skip Sheathing, Hidden Dry Rot & Smart Sequencing</a></h3>
-            <p>Photos and field notes from real jobs—what we found, how we fixed it, and what we wish the last crew had done.</p>
+            <a class="text-link" href="/blog/cdx-vs-osb.html">Read the guide <span aria-hidden="true">→</span></a>
           </div>
         </article>
       </div>
-      <!-- ADD MORE STORY POSTS as needed -->
     </section>
 
-    <!-- =========================================================
-         10% LIGHT CTA — “Ask a Pro” (kept gentle, not salesy)
-         ========================================================= -->
-    <section class="section" aria-labelledby="cta-heading">
-      <div class="kicker">Have a question?</div>
-      <h2 id="cta-heading">Ask a Pro, Free for Homeowners</h2>
-      <div class="cta-rail">
-        <div>
-          <p>Unsure about a leak, insurance photos, or the right underlayment? Send us a couple pictures and your address—we’ll point you in the right direction.</p>
-          <div class="cta-box">
-            <p style="margin:0 0 .25rem;"><strong>Quick Disclaimer:</strong> Tips on this blog are general info for common scenarios. Final scope, warranty, and liability are defined by your signed contract.</p>
-            <!-- You requested “hide the legal” tone—this stays brief and friendly -->
-          </div>
+    <section class="blog-library" id="roofing-guides" aria-labelledby="roofing-guides-title">
+      <div class="shell">
+        <div class="blog-section-heading">
+          <div><span class="eyebrow">DIY &amp; education</span><h2 id="roofing-guides-title">Know your roof.</h2></div>
+          <p>Quick wins, honest comparisons and smarter questions to ask before approving a repair, replacement or inspection.</p>
         </div>
-        <div>
-          <a class="btn" href="/#estimate">Get Guidance</a>
-          <!-- If you prefer a dedicated page, link to /contact/ or /free-inspection/ -->
+
+        <div class="resource-grid">
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/solar-racking-stanchions.html"><img src="/images/clay-tile-roof-repair/solar-installation-exposed-underlayment-1200.webp" alt="Solar installation area with exposed roof underlayment" width="1200" height="900" loading="lazy"><span>Solar • Best Practice</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">02</span><h3><a href="/blog/solar-racking-stanchions.html">Solar Racking: Why Proper Stanchions &amp; Flashings Beat “Bolt-On” Shortcuts</a></h3><p>Penetrations are forever. See how correct stanchion hardware, under-shingle flashing and sealant stack-ups keep arrays watertight.</p><a class="text-link" href="/blog/solar-racking-stanchions.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/peel-and-stick-vs-felt.html"><img src="/images/clay-tile-roof-repair/clay-roof-new-underlayment-1200.webp" alt="New roof underlayment installed beneath clay tile" width="1200" height="900" loading="lazy"><span>Underlayment • Upgrades</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">03</span><h3><a href="/blog/peel-and-stick-vs-felt.html">Peel-and-Stick vs. Felt: Where the Upgrade Pays Off</a></h3><p>Self-adhered membranes shine on low slopes, dead valleys and eaves. Learn where the extra protection makes practical sense.</p><a class="text-link" href="/blog/peel-and-stick-vs-felt.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/tpo-vs-torch.html"><img src="/images/torch-down-point-loma-720.webp" alt="Completed torch-down flat roofing system in Point Loma" width="720" height="720" loading="lazy"><span>Flat Roofs • Comparison</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">04</span><h3><a href="/blog/tpo-vs-torch.html">TPO vs Torch-Down: Which System Fits Your Flat Roof?</a></h3><p>TPO is reflective and seam-welded; torch-down is rugged and repair-friendly. Understand where each system fits.</p><a class="text-link" href="/blog/tpo-vs-torch.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/repair-vs-replace-30-years.html"><img src="/images/roof-tune-up/older-tile-roof-maintenance-overview-1200.webp" alt="Older tile roof being evaluated for maintenance or replacement" width="1200" height="900" loading="lazy"><span>Decision Guide</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">05</span><h3><a href="/blog/repair-vs-replace-30-years.html">Repair or Replace? The 30-Year Reality Check</a></h3><p>At roughly 30 years, underlayment and fasteners age out. Learn how to weigh hidden damage, future risk and the cost curve.</p><a class="text-link" href="/blog/repair-vs-replace-30-years.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/termites-from-leaks.html"><img src="/images/flat-roof-repair/bur-roof-damaged-deck-1200.webp" alt="Moisture-damaged roof deck exposed during repair" width="1200" height="900" loading="lazy"><span>Damage • San Diego</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">06</span><h3><a href="/blog/termites-from-leaks.html">San Diego Termites &amp; Roof Leaks: The Hidden Connection</a></h3><p>Moisture invites pests. Learn the early signs in fascia and eaves and why timely leak control protects the structure.</p><a class="text-link" href="/blog/termites-from-leaks.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/wood-shakes-under-shingles.html"><img src="/images/shingle-roof-repair/san-diego-sectional-shingle-repair-1200.webp" alt="Sectional shingle roof repair exposing the existing roof assembly" width="1200" height="900" loading="lazy"><span>Legacy Roofs • Inspection</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">07</span><h3><a href="/blog/wood-shakes-under-shingles.html">Wood Shakes Under Your Shingles? Check for Skip Sheathing</a></h3><p>Older homes may hide shakes and skip sheathing beneath newer shingles. Check the attic before planning the work.</p><a class="text-link" href="/blog/wood-shakes-under-shingles.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/why-professional-roof-report.html"><img src="/images/zenith-van-optimized.jpg" alt="Zenith Roofing Services vehicle at a documented roof inspection" width="1000" height="750" loading="lazy"><span>Reports • Real Estate</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">08</span><h3><a href="/blog/why-professional-roof-report.html">Why a Professional Roof Report Beats Guesswork</a></h3><p>A good report documents decking, underlayment, penetrations, flashing and drainage so decisions are based on evidence.</p><a class="text-link" href="/blog/why-professional-roof-report.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/insurance-claims-san-diego-wind.html"><img src="/images/roof-tune-up/tile-roof-slipped-tiles-1200.webp" alt="Slipped roofing tiles requiring storm and damage documentation" width="1200" height="900" loading="lazy"><span>Insurance • Wind</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">09</span><h3><a href="/blog/insurance-claims-san-diego-wind.html">Insurance Claims in San Diego: Wind Is the Usual Suspect</a></h3><p>From lifted tabs to displaced roofing, learn what to document, what may be covered and when to involve a professional.</p><a class="text-link" href="/blog/insurance-claims-san-diego-wind.html">Read guide <span>→</span></a></div>
+          </article>
+
+          <article class="resource-card">
+            <a class="resource-card__media" href="/blog/ponding-water-crickets-diverters.html"><img src="/images/roof-tune-up/commercial-roof-drains-before-1200.webp" alt="Commercial flat-roof drains before professional maintenance" width="1200" height="900" loading="lazy"><span>Drainage • Commercial</span></a>
+            <div class="resource-card__body"><span class="resource-card__number">10</span><h3><a href="/blog/ponding-water-crickets-diverters.html">Ponding Water: Problem or Just a Flat-Roof Reality?</a></h3><p>Understand drains, clogs, crickets, diverters and when a tapered system is worth the added project cost.</p><a class="text-link" href="/blog/ponding-water-crickets-diverters.html">Read guide <span>→</span></a></div>
+          </article>
         </div>
       </div>
     </section>
 
-    <!-- =========================================================
-         INTERNAL AUTHORING NOTES (won’t display)
-         • Where to add photos: each .card-media; save images under /images/blog/*.webp
-         • How to add posts: duplicate a card, create a matching /blog/your-slug.html page
-         • Keep titles punchy (≤70 chars) and summaries ≤160 chars for SEO
-         • Use cities in body copy (Escondido, Temecula, Oceanside, Carlsbad) naturally
-         • Link service pages where relevant to help internal SEO
-         • Aim for 70% education, 20% story, 10% light CTA on the index
-         ========================================================= -->
+    <section class="blog-notebook" aria-labelledby="notebook-title">
+      <div class="shell">
+        <div class="blog-section-heading blog-section-heading--light">
+          <div><span class="eyebrow eyebrow--light">From Bryan’s notebook</span><h2 id="notebook-title">Craft, roots &amp; doing it right.</h2></div>
+          <p>Lessons from the roof: why preparation matters, how documentation protects everyone and what separates a temporary patch from dependable workmanship.</p>
+        </div>
+        <div class="notebook-grid">
+          <article class="notebook-card"><a class="notebook-card__media" href="/blog/bryan-escondido-story.html"><img src="/images/zenith-sign-forklift-720.webp" alt="Zenith Roofing Services local company sign" width="720" height="720" loading="lazy"><span class="notebook-card__shade"></span></a><div class="notebook-card__body"><span>Heritage</span><h3><a href="/blog/bryan-escondido-story.html">Born &amp; Raised in North County: Why We Treat Every Roof Like Our Own</a></h3><p>Preparation, honest photos and clean job sites—the field lessons that continue to guide Zenith.</p><a class="text-link" href="/blog/bryan-escondido-story.html">Read the story <span>→</span></a></div></article>
+          <article class="notebook-card"><a class="notebook-card__media" href="/blog/why-warranty-matters.html"><img src="/images/tile-roof-repair/chimney-flashing-underlayment-detail-1200.webp" alt="Detailed roof flashing and underlayment workmanship" width="1200" height="900" loading="lazy"><span class="notebook-card__shade"></span></a><div class="notebook-card__body"><span>Craft</span><h3><a href="/blog/why-warranty-matters.html">Why Manufacturer Specs &amp; Warranty Paths Matter</a></h3><p>Following specifications on underlayment, flashings and terminations protects the roof and its warranty.</p><a class="text-link" href="/blog/why-warranty-matters.html">Read the story <span>→</span></a></div></article>
+          <article class="notebook-card"><a class="notebook-card__media" href="/blog/repair-stories-skip-sheathing.html"><img src="/images/tile-roof-repair/tile-roof-chimney-tearoff-damage-1200.webp" alt="Hidden roof damage found during a documented repair" width="1200" height="900" loading="lazy"><span class="notebook-card__shade"></span></a><div class="notebook-card__body"><span>Repair Stories</span><h3><a href="/blog/repair-stories-skip-sheathing.html">Repair Stories: Skip Sheathing, Hidden Dry Rot &amp; Smart Sequencing</a></h3><p>What we found, how we repaired it and what the previous installation should have done differently.</p><a class="text-link" href="/blog/repair-stories-skip-sheathing.html">Read the story <span>→</span></a></div></article>
+        </div>
+      </div>
+    </section>
 
+    <section class="blog-question" aria-labelledby="question-title">
+      <div class="shell blog-question__layout">
+        <div>
+          <span class="eyebrow">Have a roofing question?</span>
+          <h2 id="question-title">Start with a clear answer.</h2>
+          <p>Unsure about a leak, insurance photos, underlayment or the right roofing system? Send us your property information and we’ll help identify the clearest next step.</p>
+          <p class="blog-question__disclaimer"><strong>Quick disclaimer:</strong> Resources on this page provide general information for common roofing scenarios. Final scope, warranty and responsibility are defined by the applicable inspection, proposal and signed agreement.</p>
+        </div>
+        <aside class="blog-question__card" aria-label="Contact Zenith Roofing">
+          <span aria-hidden="true">?</span>
+          <small>Local response</small>
+          <strong>Ask Zenith Roofing</strong>
+          <p>Clear recommendations from a licensed Southern California roofing contractor.</p>
+          <a class="button button--orange button--full" href="/contact/">Get Roofing Guidance <span aria-hidden="true">→</span></a>
+          <a class="blog-question__phone" href="tel:8589006163">Or&nbsp;call&nbsp;858&#8209;900&#8209;6163</a>
+        </aside>
+      </div>
+    </section>
   </main>
 
-  <!-- ===== FOOTER INCLUDE ===== -->
-  
-
-  <!-- ===== EXISTING PARTIAL LOADER (already in your site) ===== -->
-    <div data-include="/components/footer.html"></div>
+  <div data-include="/components/footer.html"></div>
   <script src="/js/loader.js" defer></script>
 </body>
 </html>

--- a/css/blog-premium.css
+++ b/css/blog-premium.css
@@ -1,0 +1,833 @@
+/* Premium Resources / Blog directory — scoped to /blog/. */
+
+.blog-page {
+  overflow: hidden;
+  background: var(--white);
+}
+
+.blog-page h2,
+.blog-page h3,
+.blog-page p {
+  margin-top: 0;
+}
+
+.blog-page .blog-hero {
+  min-height: 730px;
+}
+
+.blog-page .blog-hero > img {
+  object-position: center 50%;
+}
+
+.blog-page .blog-hero .interior-hero__shade {
+  background:
+    linear-gradient(90deg, rgba(3, 20, 38, .99) 0%, rgba(3, 26, 48, .93) 47%, rgba(3, 26, 48, .6) 76%, rgba(3, 26, 48, .4) 100%),
+    linear-gradient(0deg, rgba(3, 26, 48, .62), transparent 62%);
+}
+
+.blog-page .blog-hero__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(310px, .54fr);
+  align-items: center;
+  gap: clamp(55px, 8vw, 125px);
+}
+
+.blog-page .blog-hero__copy h1 {
+  max-width: 980px;
+}
+
+.blog-page .blog-hero__copy > p {
+  max-width: 780px;
+  margin: 27px 0 0;
+  color: rgba(255, 255, 255, .8);
+  font-size: 1.08rem;
+  line-height: 1.8;
+}
+
+.blog-page .blog-hero__edition {
+  position: relative;
+  padding: 38px 35px 34px;
+  overflow: hidden;
+  color: var(--white);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, .16), rgba(255, 255, 255, .07)),
+    rgba(3, 26, 48, .36);
+  border: 1px solid rgba(255, 255, 255, .24);
+  border-radius: 28px;
+  box-shadow: 0 28px 70px rgba(2, 15, 29, .34), inset 0 1px 0 rgba(255, 255, 255, .14);
+  backdrop-filter: blur(18px);
+}
+
+.blog-page .blog-hero__edition::after {
+  position: absolute;
+  right: -78px;
+  bottom: -105px;
+  width: 220px;
+  height: 220px;
+  content: "";
+  background: radial-gradient(circle, rgba(255, 130, 0, .23), transparent 68%);
+  border: 1px solid rgba(255, 255, 255, .08);
+  border-radius: 50%;
+}
+
+.blog-page .blog-hero__edition-label {
+  display: inline-flex;
+  padding: 8px 12px;
+  color: #ffd3a6;
+  background: rgba(255, 130, 0, .12);
+  border: 1px solid rgba(255, 154, 57, .28);
+  border-radius: 999px;
+  font-size: .6rem;
+  font-weight: 850;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.blog-page .blog-hero__edition > strong {
+  display: block;
+  margin-top: 21px;
+  color: #ff9a39;
+  font-size: clamp(4.2rem, 6.5vw, 6.5rem);
+  font-weight: 820;
+  letter-spacing: -.08em;
+  line-height: .9;
+}
+
+.blog-page .blog-hero__edition h2 {
+  max-width: 250px;
+  margin: 12px 0 18px;
+  color: var(--white);
+  font-size: 1.42rem;
+  font-weight: 760;
+  letter-spacing: -.035em;
+  line-height: 1.2;
+}
+
+.blog-page .blog-hero__edition p {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 22px;
+  color: rgba(255, 255, 255, .67);
+  font-size: .77rem;
+  line-height: 1.65;
+}
+
+.blog-page .blog-hero__edition-proof {
+  position: relative;
+  z-index: 1;
+  display: block;
+  padding-top: 18px;
+  color: rgba(255, 255, 255, .54);
+  border-top: 1px solid rgba(255, 255, 255, .13);
+  font-size: .62rem;
+  font-weight: 750;
+  letter-spacing: .04em;
+}
+
+.blog-page .blog-feature,
+.blog-page .blog-library,
+.blog-page .blog-notebook,
+.blog-page .blog-question {
+  position: relative;
+  padding: 116px 0;
+}
+
+.blog-page .blog-section-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(310px, .72fr);
+  align-items: end;
+  gap: clamp(48px, 8vw, 118px);
+  margin-bottom: 50px;
+}
+
+.blog-page .blog-section-heading h2,
+.blog-page .blog-question h2 {
+  margin: 0;
+  color: var(--navy-950);
+  font-size: clamp(2.9rem, 4.7vw, 4.9rem);
+  font-weight: 760;
+  letter-spacing: -.06em;
+  line-height: 1.02;
+  text-wrap: balance;
+}
+
+.blog-page .blog-section-heading > p {
+  margin: 0 0 4px;
+  color: var(--ink-700);
+  font-size: 1rem;
+  line-height: 1.78;
+}
+
+.blog-page .blog-feature {
+  background: var(--white);
+}
+
+.blog-page .featured-resource {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(350px, .7fr);
+  min-height: 560px;
+  overflow: hidden;
+  background: var(--white);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 30px;
+  box-shadow: var(--shadow-md);
+}
+
+.blog-page .featured-resource__media {
+  position: relative;
+  display: block;
+  min-height: 520px;
+  overflow: hidden;
+  background: var(--navy-900);
+}
+
+.blog-page .featured-resource__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform .85s var(--ease);
+}
+
+.blog-page .featured-resource:hover .featured-resource__media img {
+  transform: scale(1.045);
+}
+
+.blog-page .featured-resource__shade {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(0deg, rgba(3, 26, 48, .67), transparent 55%),
+    linear-gradient(90deg, transparent 70%, rgba(3, 26, 48, .16));
+}
+
+.blog-page .featured-resource__badge {
+  position: absolute;
+  bottom: 26px;
+  left: 27px;
+  padding: 9px 13px;
+  color: var(--white);
+  background: rgba(3, 26, 48, .54);
+  border: 1px solid rgba(255, 255, 255, .25);
+  border-radius: 999px;
+  font-size: .61rem;
+  font-weight: 850;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  backdrop-filter: blur(12px);
+}
+
+.blog-page .featured-resource__body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: clamp(38px, 5vw, 66px);
+  overflow: hidden;
+}
+
+.blog-page .featured-resource__body::after {
+  position: absolute;
+  right: -75px;
+  bottom: -100px;
+  width: 230px;
+  height: 230px;
+  content: "";
+  background: radial-gradient(circle, rgba(42, 131, 196, .1), transparent 68%);
+  border-radius: 50%;
+}
+
+.blog-page .featured-resource__number {
+  color: var(--orange-600);
+  font-size: .65rem;
+  font-weight: 900;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+
+.blog-page .featured-resource h3 {
+  max-width: 520px;
+  margin: 20px 0 0;
+  color: var(--navy-950);
+  font-size: clamp(2rem, 3vw, 3.15rem);
+  font-weight: 750;
+  letter-spacing: -.055em;
+  line-height: 1.08;
+}
+
+.blog-page .featured-resource h3 a,
+.blog-page .resource-card h3 a,
+.blog-page .notebook-card h3 a {
+  transition: color .25s ease;
+}
+
+.blog-page .featured-resource h3 a:hover,
+.blog-page .resource-card h3 a:hover,
+.blog-page .notebook-card h3 a:hover {
+  color: var(--orange-600);
+}
+
+.blog-page .featured-resource__body > p {
+  max-width: 540px;
+  margin: 22px 0 27px;
+  color: var(--ink-500);
+  font-size: .87rem;
+  line-height: 1.78;
+}
+
+.blog-page .featured-resource .text-link {
+  position: relative;
+  z-index: 1;
+}
+
+.blog-page .blog-library {
+  background:
+    radial-gradient(circle at 4% 7%, rgba(42, 131, 196, .09), transparent 25rem),
+    var(--mist);
+}
+
+.blog-page .resource-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.blog-page .resource-card {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+  background: rgba(255, 255, 255, .98);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-radius: 23px;
+  box-shadow: var(--shadow-sm);
+  transition: transform .42s var(--ease), box-shadow .42s var(--ease), border-color .3s ease;
+}
+
+.blog-page .resource-card:hover {
+  border-color: rgba(237, 106, 0, .32);
+  box-shadow: 0 24px 58px rgba(6, 41, 75, .14);
+  transform: translateY(-7px);
+}
+
+.blog-page .resource-card__media {
+  position: relative;
+  display: block;
+  height: 235px;
+  overflow: hidden;
+  background: var(--navy-900);
+}
+
+.blog-page .resource-card__media::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(0deg, rgba(3, 26, 48, .68), transparent 57%);
+}
+
+.blog-page .resource-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform .75s var(--ease);
+}
+
+.blog-page .resource-card:hover .resource-card__media img {
+  transform: scale(1.06);
+}
+
+.blog-page .resource-card__media > span {
+  position: absolute;
+  right: 17px;
+  bottom: 16px;
+  z-index: 2;
+  padding: 7px 10px;
+  color: var(--white);
+  background: rgba(3, 26, 48, .56);
+  border: 1px solid rgba(255, 255, 255, .22);
+  border-radius: 999px;
+  font-size: .55rem;
+  font-weight: 850;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  backdrop-filter: blur(10px);
+}
+
+.blog-page .resource-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 28px;
+}
+
+.blog-page .resource-card__number {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--orange-600);
+  font-size: .61rem;
+  font-weight: 900;
+  letter-spacing: .1em;
+}
+
+.blog-page .resource-card__number::after {
+  width: 32px;
+  height: 1px;
+  content: "";
+  background: var(--line);
+}
+
+.blog-page .resource-card h3 {
+  margin: 18px 0 0;
+  color: var(--navy-950);
+  font-size: 1.22rem;
+  font-weight: 750;
+  letter-spacing: -.035em;
+  line-height: 1.3;
+}
+
+.blog-page .resource-card p {
+  margin: 15px 0 23px;
+  color: var(--ink-500);
+  font-size: .78rem;
+  line-height: 1.72;
+}
+
+.blog-page .resource-card .text-link {
+  margin-top: auto;
+  color: var(--navy-800);
+  font-size: .72rem;
+}
+
+.blog-page .blog-notebook {
+  color: var(--white);
+  background:
+    radial-gradient(circle at 94% 7%, rgba(42, 131, 196, .23), transparent 28rem),
+    radial-gradient(circle at 4% 92%, rgba(255, 130, 0, .08), transparent 25rem),
+    linear-gradient(145deg, var(--navy-950), #052846);
+}
+
+.blog-page .blog-section-heading--light h2 {
+  color: var(--white);
+}
+
+.blog-page .blog-section-heading--light > p {
+  color: rgba(255, 255, 255, .64);
+}
+
+.blog-page .notebook-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.blog-page .notebook-card {
+  overflow: hidden;
+  background: rgba(255, 255, 255, .055);
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: 24px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .05);
+  transition: transform .42s var(--ease), background-color .3s ease, border-color .3s ease;
+}
+
+.blog-page .notebook-card:hover {
+  background: rgba(255, 255, 255, .085);
+  border-color: rgba(255, 154, 57, .34);
+  transform: translateY(-7px);
+}
+
+.blog-page .notebook-card__media {
+  position: relative;
+  display: block;
+  height: 265px;
+  overflow: hidden;
+}
+
+.blog-page .notebook-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform .75s var(--ease);
+}
+
+.blog-page .notebook-card:hover .notebook-card__media img {
+  transform: scale(1.055);
+}
+
+.blog-page .notebook-card__shade {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(3, 26, 48, .76), transparent 65%);
+}
+
+.blog-page .notebook-card__body {
+  padding: 29px;
+}
+
+.blog-page .notebook-card__body > span {
+  color: #ff9f43;
+  font-size: .6rem;
+  font-weight: 900;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.blog-page .notebook-card h3 {
+  margin: 16px 0 0;
+  color: var(--white);
+  font-size: 1.24rem;
+  font-weight: 740;
+  letter-spacing: -.035em;
+  line-height: 1.32;
+}
+
+.blog-page .notebook-card h3 a:hover {
+  color: #ffab55;
+}
+
+.blog-page .notebook-card p {
+  margin: 16px 0 23px;
+  color: rgba(255, 255, 255, .61);
+  font-size: .78rem;
+  line-height: 1.7;
+}
+
+.blog-page .notebook-card .text-link {
+  color: #ffab55;
+  font-size: .72rem;
+}
+
+.blog-page .blog-question {
+  background:
+    radial-gradient(circle at 80% 20%, rgba(42, 131, 196, .12), transparent 24rem),
+    linear-gradient(145deg, #eef4f8, #f9fbfc);
+}
+
+.blog-page .blog-question__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(330px, .55fr);
+  align-items: center;
+  gap: clamp(55px, 9vw, 135px);
+}
+
+.blog-page .blog-question__layout > div > p:not(.blog-question__disclaimer) {
+  max-width: 760px;
+  margin: 26px 0 0;
+  color: var(--ink-700);
+  font-size: .96rem;
+  line-height: 1.82;
+}
+
+.blog-page .blog-question__disclaimer {
+  max-width: 780px;
+  margin: 27px 0 0;
+  padding: 20px 22px;
+  color: var(--ink-700);
+  background: rgba(255, 255, 255, .75);
+  border: 1px solid rgba(6, 41, 75, .1);
+  border-left: 4px solid var(--orange-500);
+  border-radius: 15px;
+  font-size: .73rem;
+  line-height: 1.65;
+}
+
+.blog-page .blog-question__card {
+  position: relative;
+  padding: 37px;
+  overflow: hidden;
+  color: var(--white);
+  background:
+    radial-gradient(circle at 95% 0%, rgba(42, 131, 196, .3), transparent 44%),
+    linear-gradient(145deg, var(--navy-800), var(--navy-950));
+  border-radius: 28px;
+  box-shadow: var(--shadow-lg);
+}
+
+.blog-page .blog-question__card > span {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  margin-bottom: 35px;
+  place-items: center;
+  color: var(--navy-950);
+  background: linear-gradient(135deg, #ffb24e, var(--orange-500));
+  border-radius: 17px;
+  box-shadow: 0 12px 28px rgba(237, 106, 0, .25);
+  font-size: 1.05rem;
+  font-weight: 900;
+}
+
+.blog-page .blog-question__card small {
+  display: block;
+  margin-bottom: 9px;
+  color: #ffab55;
+  font-size: .61rem;
+  font-weight: 850;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.blog-page .blog-question__card > strong {
+  display: block;
+  color: var(--white);
+  font-size: 1.65rem;
+  letter-spacing: -.045em;
+  line-height: 1.2;
+}
+
+.blog-page .blog-question__card > p {
+  margin: 17px 0 27px;
+  color: rgba(255, 255, 255, .65);
+  font-size: .8rem;
+  line-height: 1.7;
+}
+
+.blog-page .blog-question__phone {
+  display: block;
+  margin-top: 18px;
+  color: rgba(255, 255, 255, .65);
+  font-size: .7rem;
+  font-weight: 760;
+  text-align: center;
+  transition: color .25s ease;
+}
+
+.blog-page .blog-question__phone:hover {
+  color: #ffab55;
+}
+
+@media (min-width: 1440px) {
+  .trust-ribbon .shell,
+  .site-header .shell,
+  .blog-page .shell,
+  .site-footer .shell {
+    width: min(1540px, calc(100% - 136px));
+  }
+
+  .blog-page .blog-hero {
+    min-height: 820px;
+  }
+
+  .blog-page .blog-hero__copy h1 {
+    max-width: 1120px;
+    font-size: clamp(5.4rem, 5.8vw, 7.15rem) !important;
+  }
+
+  .blog-page .blog-hero__copy > p {
+    max-width: 920px;
+    font-size: 1.22rem;
+  }
+
+  .blog-page .blog-feature,
+  .blog-page .blog-library,
+  .blog-page .blog-notebook,
+  .blog-page .blog-question {
+    padding: 148px 0;
+  }
+
+  .blog-page .featured-resource {
+    min-height: 650px;
+  }
+
+  .blog-page .resource-card__media {
+    height: 285px;
+  }
+
+  .blog-page .notebook-card__media {
+    height: 315px;
+  }
+}
+
+@media (max-width: 1120px) {
+  .blog-page .blog-hero__content {
+    grid-template-columns: minmax(0, 1fr) 295px;
+    gap: 44px;
+  }
+
+  .blog-page .resource-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 960px) {
+  .blog-page .blog-hero {
+    min-height: auto;
+  }
+
+  .blog-page .blog-hero__content {
+    grid-template-columns: 1fr;
+    gap: 38px;
+    padding-top: 82px;
+    padding-bottom: 74px;
+  }
+
+  .blog-page .blog-hero__edition {
+    width: min(100%, 570px);
+  }
+
+  .blog-page .blog-section-heading,
+  .blog-page .featured-resource,
+  .blog-page .blog-question__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-page .blog-section-heading {
+    align-items: start;
+    gap: 20px;
+  }
+
+  .blog-page .blog-section-heading > p {
+    max-width: 720px;
+  }
+
+  .blog-page .featured-resource__media {
+    min-height: 450px;
+  }
+
+  .blog-page .blog-question__layout {
+    gap: 45px;
+  }
+
+  .blog-page .blog-question__card {
+    width: min(100%, 600px);
+  }
+}
+
+@media (max-width: 760px) {
+  .blog-page .blog-hero > img {
+    object-position: 58% center;
+  }
+
+  .blog-page .blog-hero .interior-hero__shade {
+    background: linear-gradient(90deg, rgba(3, 20, 38, .97), rgba(3, 26, 48, .78));
+  }
+
+  .blog-page .interior-trust__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .blog-page .interior-trust__grid > span:nth-child(3) {
+    border-left: 0;
+  }
+
+  .blog-page .interior-trust__grid > span:nth-child(n + 3) {
+    border-top: 1px solid rgba(6, 41, 75, .1);
+  }
+
+  .blog-page .blog-feature,
+  .blog-page .blog-library,
+  .blog-page .blog-notebook,
+  .blog-page .blog-question {
+    padding: 84px 0;
+  }
+
+  .blog-page .featured-resource {
+    min-height: auto;
+    border-radius: 24px;
+  }
+
+  .blog-page .featured-resource__media {
+    min-height: 365px;
+  }
+
+  .blog-page .resource-grid,
+  .blog-page .notebook-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-page .resource-card__media,
+  .blog-page .notebook-card__media {
+    height: 280px;
+  }
+}
+
+@media (max-width: 560px) {
+  .blog-page .blog-hero__content {
+    padding-top: 68px;
+    padding-bottom: 62px;
+  }
+
+  .blog-page .blog-hero__copy h1 {
+    font-size: clamp(2.75rem, 13.2vw, 3.7rem) !important;
+  }
+
+  .blog-page .blog-hero__copy > p {
+    font-size: .9rem;
+    line-height: 1.7;
+  }
+
+  .blog-page .interior-hero__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .blog-page .interior-hero__actions .button {
+    width: 100%;
+  }
+
+  .blog-page .blog-hero__edition {
+    padding: 28px 24px 26px;
+    border-radius: 22px;
+  }
+
+  .blog-page .blog-hero__edition > strong {
+    font-size: 4.2rem;
+  }
+
+  .blog-page .interior-trust__grid > span {
+    min-height: 90px;
+    padding: 14px 12px 14px 36px;
+  }
+
+  .blog-page .interior-trust__grid > span::before {
+    left: 10px;
+  }
+
+  .blog-page .interior-trust__grid b {
+    font-size: .67rem;
+  }
+
+  .blog-page .interior-trust__grid small {
+    font-size: .56rem;
+  }
+
+  .blog-page .blog-section-heading h2,
+  .blog-page .blog-question h2 {
+    font-size: clamp(2.5rem, 12vw, 3.3rem);
+  }
+
+  .blog-page .featured-resource__media {
+    min-height: 290px;
+  }
+
+  .blog-page .featured-resource__body {
+    padding: 30px 24px 34px;
+  }
+
+  .blog-page .featured-resource h3 {
+    font-size: 1.8rem;
+  }
+
+  .blog-page .resource-card__media,
+  .blog-page .notebook-card__media {
+    height: 230px;
+  }
+
+  .blog-page .resource-card__body,
+  .blog-page .notebook-card__body {
+    padding: 25px;
+  }
+
+  .blog-page .blog-question__card {
+    padding: 29px 24px;
+    border-radius: 23px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog-page .featured-resource__media img,
+  .blog-page .resource-card__media img,
+  .blog-page .notebook-card__media img {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What changed
- Rebuilt `/blog/` as the premium Zenith Resources page
- Added an image-led hero, contractor-authority proof bar, featured guide, nine-card education library, Bryan’s field-notebook stories, and a property-owner guidance CTA
- Replaced empty placeholder media with existing real Zenith roofing photography
- Added polished brand-aligned hover effects, large-screen scaling, tablet layouts, and mobile stacking while retaining the permanent mobile Home/Call/Text/Estimate/Menu dock
- Improved page metadata and expanded Blog structured data for the existing resources

## Preserved
- All 13 existing article URLs
- Existing educational topics, descriptions, story content, canonical route, header, footer, and navigation behavior
- No forms, service pages, Financing files, or article destinations were changed

## QA
- `html-validate blog/index.html`
- `git diff --check`
- All 13 original article URLs compared against `main` and verified unchanged
- All 14 referenced images verified present
- JSON-LD parsed successfully
- CSS brace integrity and duplicate-ID checks passed