### PR TITLE
Fix Projects page full-width layout

### DIFF
--- a/css/projects-premium.css
+++ b/css/projects-premium.css
@@ -1,4 +1,4 @@
-.projects-page { color: var(--ink-950); background: var(--mist); }
+.projects-page { width: 100%; max-width: none; margin: 0 !important; padding: 0 !important; color: var(--ink-950); background: var(--mist); }
 .projects-page main { overflow: hidden; }
 
 .projects-hero {


### PR DESCRIPTION
## What changed

- Removed the unintended 20px outer gutter around the entire `/projects/` page.
- Restored full-width header, hero, main page background, and footer geometry to match the Financing page.

## Root cause

The legacy shared estimate-form stylesheet applies `padding: 20px` to `body`. The Projects page loads that stylesheet for its working estimate form, so the rule incorrectly inset the whole website.

## Scope and safety

- One scoped CSS declaration only.
- Trusty gallery/map embeds, estimate form, links, content, tracking, reCAPTCHA, and SEO remain unchanged.