### PR TITLE
Redesign Roof Tune-Up page with premium Zenith theme

### DIFF
--- a/css/roof-tune-up-premium.css
+++ b/css/roof-tune-up-premium.css
@@ -54,10 +54,10 @@
 
 .roof-tune-up-page .field-note { margin: 27px 0 0; padding: 20px 22px; color: #6b3b10; background: var(--orange-100); border-left: 5px solid var(--orange-500); border-radius: 12px; font-size: .8rem; line-height: 1.7; }
 .roof-tune-up-page .commercial-tuneup .field-note { color: #ffe0b7; background: rgba(255,130,0,.12); border-color: var(--orange-500); }
-.roof-tune-up-page .project-proof { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 16px; margin-top: 30px; }
+.roof-tune-up-page .project-proof { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); max-width: 1040px; gap: 22px; margin: 30px auto 0; }
 .roof-tune-up-page .project-proof figure { overflow: hidden; margin: 0; background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 21px; box-shadow: var(--shadow-md); transition: transform .38s var(--ease),box-shadow .38s var(--ease); }
 .roof-tune-up-page .project-proof figure:hover { transform: translateY(-5px); box-shadow: var(--shadow-lg); }
-.roof-tune-up-page .project-proof img { display: block; width: 100%; aspect-ratio: 16/10; object-fit: cover; object-position: center; }
+.roof-tune-up-page .project-proof img { display: block; width: 100%; height: clamp(220px,22vw,285px); max-height: 285px; object-fit: cover; object-position: center; }
 .roof-tune-up-page .project-proof figcaption { padding: 19px 21px 22px; color: var(--ink-500); font-size: .75rem; line-height: 1.65; }
 .roof-tune-up-page .project-proof figcaption strong { display: block; margin-bottom: 5px; color: var(--navy-950); font-size: .9rem; }
 .roof-tune-up-page .commercial-tuneup .project-proof figure { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.13); }
@@ -93,7 +93,7 @@
   .roof-tune-up-page .tuneup-hero__content { grid-template-columns: 1fr; }
   .roof-tune-up-page .tuneup-offer { max-width: 650px; }
   .roof-tune-up-page .commercial-scope { grid-template-columns: repeat(2,1fr); }
-  .roof-tune-up-page .project-proof { grid-template-columns: repeat(2,minmax(0,1fr)); }
+  .roof-tune-up-page .project-proof { gap: 16px; }
 }
 @media (max-width: 680px) {
   .roof-tune-up-page .tuneup-hero { min-height: 620px; }
@@ -106,6 +106,7 @@
   .roof-tune-up-page .section { width: min(100% - 28px,1180px); padding: 68px 0; }
   .roof-tune-up-page .section > h2,.roof-tune-up-page .sa-head h2 { font-size: clamp(2.2rem,10vw,3.05rem); }
   .roof-tune-up-page .cols-2,.roof-tune-up-page .commercial-scope,.roof-tune-up-page .project-proof,.roof-tune-up-page .decision-grid { grid-template-columns: 1fr; }
+  .roof-tune-up-page .project-proof img { height: 220px; max-height: 220px; }
   .roof-tune-up-page .commercial-tuneup { padding-right: 14px; padding-left: 14px; }
   .roof-tune-up-page .estimate-form-section { width: calc(100% - 28px); padding: 25px 18px; }
   .roof-tune-up-page .cta-strip { flex-direction: column; align-items: flex-start; }

--- a/css/roof-tune-up-premium.css
+++ b/css/roof-tune-up-premium.css
@@ -54,10 +54,10 @@
 
 .roof-tune-up-page .field-note { margin: 27px 0 0; padding: 20px 22px; color: #6b3b10; background: var(--orange-100); border-left: 5px solid var(--orange-500); border-radius: 12px; font-size: .8rem; line-height: 1.7; }
 .roof-tune-up-page .commercial-tuneup .field-note { color: #ffe0b7; background: rgba(255,130,0,.12); border-color: var(--orange-500); }
-.roof-tune-up-page .project-proof { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 17px; margin-top: 30px; }
+.roof-tune-up-page .project-proof { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 16px; margin-top: 30px; }
 .roof-tune-up-page .project-proof figure { overflow: hidden; margin: 0; background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 21px; box-shadow: var(--shadow-md); transition: transform .38s var(--ease),box-shadow .38s var(--ease); }
 .roof-tune-up-page .project-proof figure:hover { transform: translateY(-5px); box-shadow: var(--shadow-lg); }
-.roof-tune-up-page .project-proof img { display: block; width: 100%; aspect-ratio: 4/3; object-fit: cover; }
+.roof-tune-up-page .project-proof img { display: block; width: 100%; aspect-ratio: 16/10; object-fit: cover; object-position: center; }
 .roof-tune-up-page .project-proof figcaption { padding: 19px 21px 22px; color: var(--ink-500); font-size: .75rem; line-height: 1.65; }
 .roof-tune-up-page .project-proof figcaption strong { display: block; margin-bottom: 5px; color: var(--navy-950); font-size: .9rem; }
 .roof-tune-up-page .commercial-tuneup .project-proof figure { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.13); }
@@ -93,6 +93,7 @@
   .roof-tune-up-page .tuneup-hero__content { grid-template-columns: 1fr; }
   .roof-tune-up-page .tuneup-offer { max-width: 650px; }
   .roof-tune-up-page .commercial-scope { grid-template-columns: repeat(2,1fr); }
+  .roof-tune-up-page .project-proof { grid-template-columns: repeat(2,minmax(0,1fr)); }
 }
 @media (max-width: 680px) {
   .roof-tune-up-page .tuneup-hero { min-height: 620px; }

--- a/css/roof-tune-up-premium.css
+++ b/css/roof-tune-up-premium.css
@@ -40,7 +40,7 @@
 .roof-tune-up-page .tick { display: inline-grid; width: 23px; height: 23px; flex: 0 0 auto; place-items: center; color: var(--white); background: var(--orange-500); border-radius: 50%; font-size: .65rem; font-weight: 900; }
 .roof-tune-up-page .center-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 30px; }
 
-.roof-tune-up-page .commercial-tuneup { width: 100%; padding-right: max(28px,calc((100vw - 1180px)/2)); padding-left: max(28px,calc((100vw - 1180px)/2)); color: var(--white); background: radial-gradient(circle at 100% 0,rgba(255,130,0,.17),transparent 32%),var(--navy-950); }
+.roof-tune-up-page .section.card.commercial-tuneup { width: 100%; padding-right: max(28px,calc((100vw - 1180px)/2)); padding-left: max(28px,calc((100vw - 1180px)/2)); color: var(--white); background: radial-gradient(circle at 100% 0,rgba(255,130,0,.17),transparent 32%),var(--navy-950); border-top: 0; }
 .roof-tune-up-page .commercial-tuneup h2,.roof-tune-up-page .commercial-tuneup > h3 { color: var(--white); }
 .roof-tune-up-page .commercial-tuneup .intro { color: rgba(255,255,255,.68); }
 .roof-tune-up-page .commercial-scope { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 15px; margin-top: 38px; }

--- a/css/roof-tune-up-premium.css
+++ b/css/roof-tune-up-premium.css
@@ -1,0 +1,111 @@
+.roof-tune-up-page { width: 100%; max-width: none; margin: 0 !important; padding: 0 !important; color: var(--ink-950); background: var(--mist); }
+.roof-tune-up-page .page { width: 100%; max-width: none; margin: 0; padding: 0 0 100px; overflow: hidden; }
+
+.roof-tune-up-page .hero { position: relative; isolation: isolate; min-height: 720px; padding: clamp(90px,11vw,145px) max(28px,calc((100vw - 1180px)/2)); color: var(--white); background: linear-gradient(90deg,rgba(3,20,38,.99),rgba(3,26,48,.93) 48%,rgba(3,26,48,.62) 76%,rgba(3,26,48,.46)),linear-gradient(0deg,rgba(3,26,48,.6),transparent 62%),url('/images/hvac-penetrations-before-after-1440.webp') center/cover no-repeat; }
+.roof-tune-up-page .hero::after { position: absolute; right: -140px; bottom: -210px; z-index: -1; width: 620px; height: 620px; background: radial-gradient(circle,rgba(255,130,0,.22),transparent 68%); content: ''; }
+.roof-tune-up-page .hero .eyebrow { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 20px; }
+.roof-tune-up-page .hero .chip { display: inline-flex; min-height: 34px; align-items: center; padding: 7px 11px; color: #ffd49b; background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.16); border-radius: 999px; font-size: .62rem; font-weight: 850; }
+.roof-tune-up-page .hero .split { display: grid; grid-template-columns: minmax(0,1.18fr) minmax(330px,.58fr); gap: clamp(55px,8vw,125px); align-items: center; }
+.roof-tune-up-page .hero h1 { margin: 0 !important; color: var(--white); font-size: clamp(3.35rem,6.35vw,6.2rem); letter-spacing: -.065em; line-height: .98; }
+.roof-tune-up-page .hero .lede { max-width: 760px; margin: 27px 0 0; color: rgba(255,255,255,.8); font-size: 1.08rem; line-height: 1.8; }
+.roof-tune-up-page .hero .lede strong { color: var(--white); }
+.roof-tune-up-page .hero .cta { display: flex; flex-wrap: wrap; gap: 11px; margin-top: 31px; }
+.roof-tune-up-page .btn { display: inline-flex; min-height: 49px; align-items: center; justify-content: center; padding: 12px 21px; border-radius: 13px; font-size: .73rem; font-weight: 900; transition: transform .3s var(--ease),box-shadow .3s ease,background .3s ease; }
+.roof-tune-up-page .btn:hover { transform: translateY(-3px); }
+.roof-tune-up-page .btn-primary { color: var(--navy-950); background: linear-gradient(135deg,#ffad43,var(--orange-500)); box-shadow: 0 11px 28px rgba(237,106,0,.24); }
+.roof-tune-up-page .btn-outline { color: var(--navy-900); background: var(--white); border: 1px solid rgba(6,41,75,.13); }
+.roof-tune-up-page .hero .btn-outline { color: var(--white); background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.22); }
+.roof-tune-up-page .photo-card { position: relative; overflow: hidden; padding: 10px; background: linear-gradient(145deg,rgba(255,255,255,.17),rgba(255,255,255,.07)),rgba(3,26,48,.32); border: 1px solid rgba(255,255,255,.25); border-radius: 28px; box-shadow: 0 28px 70px rgba(2,15,29,.34),inset 0 1px 0 rgba(255,255,255,.14); backdrop-filter: blur(18px); }
+.roof-tune-up-page .photo-card img { display: block; width: 100%; aspect-ratio: 4/5; object-fit: cover; border-radius: 19px; }
+
+.roof-tune-up-page .pillnav { position: sticky; top: 102px; z-index: 25; display: flex; width: min(100% - 36px,1100px); gap: 7px; overflow-x: auto; margin: -29px auto 0; padding: 10px; background: rgba(255,255,255,.94); border: 1px solid rgba(6,41,75,.1); border-radius: 16px; box-shadow: var(--shadow-md); backdrop-filter: blur(15px); }
+.roof-tune-up-page .pillnav a { flex: 0 0 auto; min-height: 42px; display: inline-flex; align-items: center; padding: 9px 13px; color: var(--navy-900); border-radius: 10px; font-size: .65rem; font-weight: 850; }
+.roof-tune-up-page .pillnav a:hover { color: var(--white); background: var(--navy-900); }
+
+.roof-tune-up-page .section { width: min(100% - 36px,1180px); margin: 0 auto; padding: 88px 0; }
+.roof-tune-up-page .section + .section { border-top: 1px solid rgba(6,41,75,.09); }
+.roof-tune-up-page .section.card { background: transparent; border: 0; border-radius: 0; box-shadow: none; }
+.roof-tune-up-page .section > h2,.roof-tune-up-page .sa-head h2 { max-width: 950px; margin: 0; color: var(--navy-950); font-size: clamp(2.2rem,4.7vw,4.15rem); letter-spacing: -.055em; line-height: 1.04; }
+.roof-tune-up-page .section > h3 { margin: 48px 0 0; color: var(--navy-950); font-size: clamp(1.65rem,3vw,2.4rem); letter-spacing: -.04em; }
+.roof-tune-up-page .section-kicker { margin: 0 0 12px; color: var(--orange-600); font-size: .66rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+.roof-tune-up-page .intro,.roof-tune-up-page .lede-narrow { max-width: 880px; margin: 17px 0 0; color: var(--ink-700); font-size: .88rem; line-height: 1.82; }
+.roof-tune-up-page .grid { display: grid; gap: 16px; margin-top: 36px; }
+.roof-tune-up-page .cols-2 { grid-template-columns: repeat(2,1fr); }
+.roof-tune-up-page #what .grid > div { padding: 29px; background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 20px; box-shadow: var(--shadow-sm); }
+.roof-tune-up-page .checklist { display: grid; gap: 14px; margin: 0; padding: 0; list-style: none; }
+.roof-tune-up-page .checklist li { display: flex; gap: 11px; align-items: flex-start; color: var(--ink-700); font-size: .8rem; line-height: 1.6; }
+.roof-tune-up-page .tick { display: inline-grid; width: 23px; height: 23px; flex: 0 0 auto; place-items: center; color: var(--white); background: var(--orange-500); border-radius: 50%; font-size: .65rem; font-weight: 900; }
+.roof-tune-up-page .center-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 30px; }
+
+.roof-tune-up-page .commercial-tuneup { width: 100%; padding-right: max(28px,calc((100vw - 1180px)/2)); padding-left: max(28px,calc((100vw - 1180px)/2)); color: var(--white); background: radial-gradient(circle at 100% 0,rgba(255,130,0,.17),transparent 32%),var(--navy-950); }
+.roof-tune-up-page .commercial-tuneup h2,.roof-tune-up-page .commercial-tuneup > h3 { color: var(--white); }
+.roof-tune-up-page .commercial-tuneup .intro { color: rgba(255,255,255,.68); }
+.roof-tune-up-page .commercial-scope { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 15px; margin-top: 38px; }
+.roof-tune-up-page .commercial-scope article,.roof-tune-up-page .decision-grid article { padding: 27px; background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 20px; box-shadow: var(--shadow-sm); transition: transform .38s var(--ease),box-shadow .38s var(--ease),border-color .3s ease; }
+.roof-tune-up-page .commercial-scope article:hover,.roof-tune-up-page .decision-grid article:hover { transform: translateY(-5px); border-color: rgba(255,130,0,.35); box-shadow: var(--shadow-md); }
+.roof-tune-up-page .commercial-scope h3,.roof-tune-up-page .decision-grid h3 { margin: 0; color: var(--navy-950); font-size: 1.04rem; letter-spacing: -.025em; }
+.roof-tune-up-page .commercial-scope p,.roof-tune-up-page .decision-grid p { margin: 12px 0 0; color: var(--ink-500); font-size: .76rem; line-height: 1.72; }
+.roof-tune-up-page .commercial-tuneup .commercial-scope article,.roof-tune-up-page .commercial-tuneup .decision-grid article { background: rgba(255,255,255,.075); border-color: rgba(255,255,255,.13); box-shadow: none; }
+.roof-tune-up-page .commercial-tuneup .commercial-scope h3,.roof-tune-up-page .commercial-tuneup .decision-grid h3 { color: var(--white); }
+.roof-tune-up-page .commercial-tuneup .commercial-scope p,.roof-tune-up-page .commercial-tuneup .decision-grid p { color: rgba(255,255,255,.63); }
+
+.roof-tune-up-page .field-note { margin: 27px 0 0; padding: 20px 22px; color: #6b3b10; background: var(--orange-100); border-left: 5px solid var(--orange-500); border-radius: 12px; font-size: .8rem; line-height: 1.7; }
+.roof-tune-up-page .commercial-tuneup .field-note { color: #ffe0b7; background: rgba(255,130,0,.12); border-color: var(--orange-500); }
+.roof-tune-up-page .project-proof { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 17px; margin-top: 30px; }
+.roof-tune-up-page .project-proof figure { overflow: hidden; margin: 0; background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 21px; box-shadow: var(--shadow-md); transition: transform .38s var(--ease),box-shadow .38s var(--ease); }
+.roof-tune-up-page .project-proof figure:hover { transform: translateY(-5px); box-shadow: var(--shadow-lg); }
+.roof-tune-up-page .project-proof img { display: block; width: 100%; aspect-ratio: 4/3; object-fit: cover; }
+.roof-tune-up-page .project-proof figcaption { padding: 19px 21px 22px; color: var(--ink-500); font-size: .75rem; line-height: 1.65; }
+.roof-tune-up-page .project-proof figcaption strong { display: block; margin-bottom: 5px; color: var(--navy-950); font-size: .9rem; }
+.roof-tune-up-page .commercial-tuneup .project-proof figure { background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.13); }
+.roof-tune-up-page .commercial-tuneup .project-proof figcaption { color: rgba(255,255,255,.62); }
+.roof-tune-up-page .commercial-tuneup .project-proof figcaption strong { color: var(--white); }
+.roof-tune-up-page .decision-grid { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 15px; margin-top: 26px; }
+
+.roof-tune-up-page .faq { display: grid; gap: 12px; max-width: 940px; margin-top: 36px; }
+.roof-tune-up-page .faq details { overflow: hidden; background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 16px; box-shadow: var(--shadow-sm); }
+.roof-tune-up-page .faq summary { min-height: 62px; display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; color: var(--navy-950); cursor: pointer; font-size: .82rem; font-weight: 850; }
+.roof-tune-up-page .faq summary::after { color: var(--orange-600); content: '+'; font-size: 1.25rem; }
+.roof-tune-up-page .faq details[open] summary::after { content: '−'; }
+.roof-tune-up-page .faq p { margin: 0; padding: 0 20px 20px; color: var(--ink-500); font-size: .78rem; line-height: 1.72; }
+
+.roof-tune-up-page #process .grid > .card { padding: 26px; background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 18px; box-shadow: var(--shadow-sm); }
+.roof-tune-up-page #process .grid h3 { margin: 0; color: var(--navy-950); font-size: 1rem; }
+.roof-tune-up-page #process .grid p { margin: 10px 0 0; color: var(--ink-500); font-size: .76rem; line-height: 1.65; }
+.roof-tune-up-page .chip-grid { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0 0; padding: 0; list-style: none; }
+.roof-tune-up-page .sa-chip { display: inline-flex; min-height: 39px; align-items: center; padding: 8px 12px; color: var(--navy-900); background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 999px; font-size: .68rem; font-weight: 750; }
+.roof-tune-up-page .sa-chip.strong { color: var(--white); background: var(--navy-900); }
+.roof-tune-up-page .sa-more { margin-top: 16px; }
+.roof-tune-up-page .sa-summary { color: var(--orange-600); cursor: pointer; font-size: .72rem; font-weight: 850; }
+
+.roof-tune-up-page .estimate-form-section { width: min(100% - 36px,1040px); margin-top: 35px; padding: clamp(28px,5vw,52px); background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 27px; box-shadow: var(--shadow-lg); }
+.roof-tune-up-page .form-disclaimer { margin: 18px 0 0; color: var(--ink-500); font-size: .7rem; line-height: 1.6; }
+.roof-tune-up-page .cta-strip { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: clamp(31px,5vw,52px); color: var(--white); background: linear-gradient(135deg,var(--navy-950),var(--navy-800)); border-radius: 24px; box-shadow: var(--shadow-lg); }
+.roof-tune-up-page .cta-strip .text { max-width: 700px; color: rgba(255,255,255,.72); line-height: 1.65; }
+.roof-tune-up-page .cta-strip .text strong { color: var(--white); }
+.roof-tune-up-page .cta-strip .btn { flex: 0 0 auto; color: var(--navy-950); background: linear-gradient(135deg,#ffad43,var(--orange-500)); }
+.roof-tune-up-page :is(a,button,input,select,textarea,summary):focus-visible { outline: 3px solid #75b6ff; outline-offset: 3px; }
+
+@media (max-width: 960px) {
+  .roof-tune-up-page .hero .split { grid-template-columns: 1fr; }
+  .roof-tune-up-page .photo-card { max-width: 650px; }
+  .roof-tune-up-page .photo-card img { aspect-ratio: 16/10; }
+  .roof-tune-up-page .commercial-scope { grid-template-columns: repeat(2,1fr); }
+}
+@media (max-width: 680px) {
+  .roof-tune-up-page .hero { min-height: auto; padding: 72px 14px 84px; }
+  .roof-tune-up-page .hero h1 { font-size: clamp(2.7rem,12vw,3.7rem); }
+  .roof-tune-up-page .hero .cta { flex-direction: column; }
+  .roof-tune-up-page .hero .btn { width: 100%; }
+  .roof-tune-up-page .pillnav { top: 76px; width: calc(100% - 20px); margin-top: -25px; }
+  .roof-tune-up-page .section { width: min(100% - 28px,1180px); padding: 68px 0; }
+  .roof-tune-up-page .section > h2,.roof-tune-up-page .sa-head h2 { font-size: clamp(2.2rem,10vw,3.05rem); }
+  .roof-tune-up-page .cols-2,.roof-tune-up-page .commercial-scope,.roof-tune-up-page .project-proof,.roof-tune-up-page .decision-grid { grid-template-columns: 1fr; }
+  .roof-tune-up-page .commercial-tuneup { padding-right: 14px; padding-left: 14px; }
+  .roof-tune-up-page .estimate-form-section { width: calc(100% - 28px); padding: 25px 18px; }
+  .roof-tune-up-page .cta-strip { flex-direction: column; align-items: flex-start; }
+  .roof-tune-up-page .cta-strip .btn { width: 100%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .roof-tune-up-page *, .roof-tune-up-page *::before, .roof-tune-up-page *::after { transition-duration: .01ms !important; }
+}

--- a/css/roof-tune-up-premium.css
+++ b/css/roof-tune-up-premium.css
@@ -81,8 +81,29 @@
 .roof-tune-up-page .sa-more { margin-top: 16px; }
 .roof-tune-up-page .sa-summary { color: var(--orange-600); cursor: pointer; font-size: .72rem; font-weight: 850; }
 
-.roof-tune-up-page .estimate-form-section { width: min(100% - 36px,1040px); margin-top: 35px; padding: clamp(28px,5vw,52px); background: var(--white); border: 1px solid rgba(6,41,75,.1); border-radius: 27px; box-shadow: var(--shadow-lg); }
-.roof-tune-up-page .form-disclaimer { margin: 18px 0 0; color: var(--ink-500); font-size: .7rem; line-height: 1.6; }
+.roof-tune-up-page .estimate-form-section { position: relative; width: min(100% - 36px,1040px); margin-top: 55px; padding: clamp(32px,5vw,58px); overflow: hidden; background: rgba(255,255,255,.98); border: 1px solid rgba(6,41,75,.11); border-radius: 28px; box-shadow: 0 26px 70px rgba(6,41,75,.14); }
+.roof-tune-up-page .estimate-form-section::before { position: absolute; top: 0; right: 0; left: 0; height: 5px; content: ''; background: linear-gradient(90deg,var(--orange-500),#ffb34e 44%,var(--blue-500)); }
+.roof-tune-up-page .estimate-form-heading { margin-bottom: 30px; padding-bottom: 26px; border-bottom: 1px solid rgba(6,41,75,.11); }
+.roof-tune-up-page .estimate-form-heading > span { color: var(--orange-600); font-size: .65rem; font-weight: 900; letter-spacing: .14em; text-transform: uppercase; }
+.roof-tune-up-page .estimate-form-heading h2 { margin: 9px 0 0; color: var(--navy-950); font-size: clamp(1.8rem,3.5vw,2.75rem); font-weight: 780; letter-spacing: -.045em; line-height: 1.08; }
+.roof-tune-up-page .estimate-form-heading p { max-width: 680px; margin: 12px 0 0; color: var(--ink-500); font-size: .78rem; line-height: 1.65; }
+.roof-tune-up-page .estimate-form-block #estimate-form { max-width: none; margin: 0; padding: 0; background: transparent; border-radius: 0; box-shadow: none; }
+.roof-tune-up-page .estimate-form-block .form-row { gap: 16px; margin-bottom: 16px; }
+.roof-tune-up-page .estimate-form-block .form-col-6 { flex-basis: calc(50% - 8px); }
+.roof-tune-up-page .estimate-form-block .form-col-4 { flex-basis: calc(33.333% - 11px); }
+.roof-tune-up-page .estimate-form-block :is(input,select,textarea) { min-height: 54px; padding: 13px 15px; color: var(--ink-950); background: #fbfcfd; border: 1px solid rgba(6,41,75,.16); border-radius: 12px; font: 500 16px/1.35 inherit; box-shadow: none; transition: border-color .25s ease,box-shadow .25s ease,background-color .25s ease; }
+.roof-tune-up-page .estimate-form-block textarea { min-height: 128px; resize: vertical; }
+.roof-tune-up-page .estimate-form-block :is(input,select,textarea):hover { background: var(--white); border-color: rgba(6,41,75,.3); }
+.roof-tune-up-page .estimate-form-block :is(input,select,textarea):focus { outline: none; background: var(--white); border-color: var(--orange-500); box-shadow: 0 0 0 4px rgba(255,130,0,.13); }
+.roof-tune-up-page .estimate-form-block :is(input,textarea)::placeholder { color: #7d8998; opacity: 1; }
+.roof-tune-up-page .estimate-form-block input[type='file'] { padding: 7px; color: var(--ink-500); background: #f5f8fb; }
+.roof-tune-up-page .estimate-form-block input[type='file']::file-selector-button { min-height: 38px; margin-right: 11px; padding: 8px 13px; color: var(--navy-950); background: var(--white); border: 1px solid rgba(6,41,75,.16); border-radius: 8px; font: 800 .7rem/1 inherit; cursor: pointer; transition: color .25s ease,background .25s ease,border-color .25s ease; }
+.roof-tune-up-page .estimate-form-block input[type='file']::file-selector-button:hover { color: var(--white); background: var(--navy-900); border-color: var(--navy-900); }
+.roof-tune-up-page .estimate-form-block .recaptcha-container { justify-content: flex-start; padding: 4px 0; }
+.roof-tune-up-page .estimate-form-block .zenith-btn { min-height: 56px; color: var(--navy-950); background: linear-gradient(135deg,#ffad43,var(--orange-500)); border: 0; border-radius: 13px; box-shadow: 0 13px 30px rgba(237,106,0,.25); font: 900 .78rem/1 inherit; letter-spacing: .01em; }
+.roof-tune-up-page .estimate-form-block .zenith-btn:hover { background: linear-gradient(135deg,#ffb552,#f97800); transform: translateY(-3px); box-shadow: 0 17px 36px rgba(237,106,0,.31); }
+.roof-tune-up-page .estimate-form-block .form-disclaimer,.roof-tune-up-page .estimate-form-section > .form-disclaimer { margin: 22px 0 0; padding: 18px 0 0; color: var(--ink-500); background: transparent; border: 0; border-top: 1px solid rgba(6,41,75,.11); font-size: .68rem; line-height: 1.65; }
+.roof-tune-up-page .estimate-form-block .form-disclaimer a { color: var(--orange-600); font-weight: 850; }
 .roof-tune-up-page .cta-strip { display: flex; align-items: center; justify-content: space-between; gap: 24px; padding: clamp(31px,5vw,52px); color: var(--white); background: linear-gradient(135deg,var(--navy-950),var(--navy-800)); border-radius: 24px; box-shadow: var(--shadow-lg); }
 .roof-tune-up-page .cta-strip .text { max-width: 700px; color: rgba(255,255,255,.72); line-height: 1.65; }
 .roof-tune-up-page .cta-strip .text strong { color: var(--white); }
@@ -109,6 +130,8 @@
   .roof-tune-up-page .project-proof img { height: 220px; max-height: 220px; }
   .roof-tune-up-page .commercial-tuneup { padding-right: 14px; padding-left: 14px; }
   .roof-tune-up-page .estimate-form-section { width: calc(100% - 28px); padding: 25px 18px; }
+  .roof-tune-up-page .estimate-form-block .form-col-6,.roof-tune-up-page .estimate-form-block .form-col-4 { flex-basis: 100%; }
+  .roof-tune-up-page .estimate-form-block .recaptcha-container { overflow-x: auto; }
   .roof-tune-up-page .cta-strip { flex-direction: column; align-items: flex-start; }
   .roof-tune-up-page .cta-strip .btn { width: 100%; }
 }

--- a/css/roof-tune-up-premium.css
+++ b/css/roof-tune-up-premium.css
@@ -1,22 +1,25 @@
 .roof-tune-up-page { width: 100%; max-width: none; margin: 0 !important; padding: 0 !important; color: var(--ink-950); background: var(--mist); }
 .roof-tune-up-page .page { width: 100%; max-width: none; margin: 0; padding: 0 0 100px; overflow: hidden; }
 
-.roof-tune-up-page .hero { position: relative; isolation: isolate; min-height: 720px; padding: clamp(90px,11vw,145px) max(28px,calc((100vw - 1180px)/2)); color: var(--white); background: linear-gradient(90deg,rgba(3,20,38,.99),rgba(3,26,48,.93) 48%,rgba(3,26,48,.62) 76%,rgba(3,26,48,.46)),linear-gradient(0deg,rgba(3,26,48,.6),transparent 62%),url('/images/hvac-penetrations-before-after-1440.webp') center/cover no-repeat; }
-.roof-tune-up-page .hero::after { position: absolute; right: -140px; bottom: -210px; z-index: -1; width: 620px; height: 620px; background: radial-gradient(circle,rgba(255,130,0,.22),transparent 68%); content: ''; }
-.roof-tune-up-page .hero .eyebrow { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 20px; }
-.roof-tune-up-page .hero .chip { display: inline-flex; min-height: 34px; align-items: center; padding: 7px 11px; color: #ffd49b; background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.16); border-radius: 999px; font-size: .62rem; font-weight: 850; }
-.roof-tune-up-page .hero .split { display: grid; grid-template-columns: minmax(0,1.18fr) minmax(330px,.58fr); gap: clamp(55px,8vw,125px); align-items: center; }
-.roof-tune-up-page .hero h1 { margin: 0 !important; color: var(--white); font-size: clamp(3.35rem,6.35vw,6.2rem); letter-spacing: -.065em; line-height: .98; }
-.roof-tune-up-page .hero .lede { max-width: 760px; margin: 27px 0 0; color: rgba(255,255,255,.8); font-size: 1.08rem; line-height: 1.8; }
-.roof-tune-up-page .hero .lede strong { color: var(--white); }
-.roof-tune-up-page .hero .cta { display: flex; flex-wrap: wrap; gap: 11px; margin-top: 31px; }
+.roof-tune-up-page .tuneup-hero { min-height: 720px; }
+.roof-tune-up-page .tuneup-hero > img { object-position: center 50%; }
+.roof-tune-up-page .tuneup-hero .interior-hero__shade { background: linear-gradient(90deg,rgba(3,20,38,.99) 0%,rgba(3,26,48,.93) 46%,rgba(3,26,48,.62) 75%,rgba(3,26,48,.45) 100%),linear-gradient(0deg,rgba(3,26,48,.64),transparent 62%); }
+.roof-tune-up-page .tuneup-hero__content { display: grid; grid-template-columns: minmax(0,1.25fr) minmax(330px,.58fr); align-items: center; gap: clamp(55px,8vw,125px); }
+.roof-tune-up-page .tuneup-hero__copy h1 { max-width: 940px; }
+.roof-tune-up-page .tuneup-hero__copy > p:not(.tuneup-hero__fine) { max-width: 760px; margin: 27px 0 0; color: rgba(255,255,255,.8); font-size: 1.08rem; line-height: 1.8; }
+.roof-tune-up-page .tuneup-hero__fine { max-width: 760px; margin: 22px 0 0; color: rgba(255,255,255,.62); font-size: .72rem; line-height: 1.55; }
+.roof-tune-up-page .tuneup-offer { position: relative; overflow: hidden; padding: 38px 36px 34px; color: var(--white); background: linear-gradient(145deg,rgba(255,255,255,.16),rgba(255,255,255,.07)),rgba(3,26,48,.35); border: 1px solid rgba(255,255,255,.25); border-radius: 28px; box-shadow: 0 28px 70px rgba(2,15,29,.34),inset 0 1px 0 rgba(255,255,255,.14); backdrop-filter: blur(18px); }
+.roof-tune-up-page .tuneup-offer::after { position: absolute; right: -72px; bottom: -92px; width: 205px; height: 205px; background: radial-gradient(circle,rgba(255,130,0,.24),transparent 68%); border: 1px solid rgba(255,255,255,.08); border-radius: 50%; content: ''; }
+.roof-tune-up-page .tuneup-offer__label { display: inline-flex; padding: 8px 12px; color: #ffd3a6; background: rgba(255,130,0,.12); border: 1px solid rgba(255,154,57,.28); border-radius: 999px; font-size: .62rem; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
+.roof-tune-up-page .tuneup-offer > strong { display: block; margin-top: 25px; color: var(--white); font-size: 1.05rem; font-weight: 760; line-height: 1; }
+.roof-tune-up-page .tuneup-offer > strong span { color: #ff9a39; font-size: clamp(4rem,6.2vw,6.25rem); font-weight: 820; letter-spacing: -.08em; }
+.roof-tune-up-page .tuneup-offer h2 { margin: 7px 0 18px; color: var(--white); font-size: 1.42rem; font-weight: 760; letter-spacing: -.035em; }
+.roof-tune-up-page .tuneup-offer p { position: relative; z-index: 1; margin-bottom: 20px; color: rgba(255,255,255,.68); font-size: .78rem; line-height: 1.65; }
+.roof-tune-up-page .tuneup-offer .text-link { position: relative; z-index: 1; color: #ffab55; font-size: .72rem; }
 .roof-tune-up-page .btn { display: inline-flex; min-height: 49px; align-items: center; justify-content: center; padding: 12px 21px; border-radius: 13px; font-size: .73rem; font-weight: 900; transition: transform .3s var(--ease),box-shadow .3s ease,background .3s ease; }
 .roof-tune-up-page .btn:hover { transform: translateY(-3px); }
 .roof-tune-up-page .btn-primary { color: var(--navy-950); background: linear-gradient(135deg,#ffad43,var(--orange-500)); box-shadow: 0 11px 28px rgba(237,106,0,.24); }
 .roof-tune-up-page .btn-outline { color: var(--navy-900); background: var(--white); border: 1px solid rgba(6,41,75,.13); }
-.roof-tune-up-page .hero .btn-outline { color: var(--white); background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.22); }
-.roof-tune-up-page .photo-card { position: relative; overflow: hidden; padding: 10px; background: linear-gradient(145deg,rgba(255,255,255,.17),rgba(255,255,255,.07)),rgba(3,26,48,.32); border: 1px solid rgba(255,255,255,.25); border-radius: 28px; box-shadow: 0 28px 70px rgba(2,15,29,.34),inset 0 1px 0 rgba(255,255,255,.14); backdrop-filter: blur(18px); }
-.roof-tune-up-page .photo-card img { display: block; width: 100%; aspect-ratio: 4/5; object-fit: cover; border-radius: 19px; }
 
 .roof-tune-up-page .pillnav { position: sticky; top: 102px; z-index: 25; display: flex; width: min(100% - 36px,1100px); gap: 7px; overflow-x: auto; margin: -29px auto 0; padding: 10px; background: rgba(255,255,255,.94); border: 1px solid rgba(6,41,75,.1); border-radius: 16px; box-shadow: var(--shadow-md); backdrop-filter: blur(15px); }
 .roof-tune-up-page .pillnav a { flex: 0 0 auto; min-height: 42px; display: inline-flex; align-items: center; padding: 9px 13px; color: var(--navy-900); border-radius: 10px; font-size: .65rem; font-weight: 850; }
@@ -87,16 +90,17 @@
 .roof-tune-up-page :is(a,button,input,select,textarea,summary):focus-visible { outline: 3px solid #75b6ff; outline-offset: 3px; }
 
 @media (max-width: 960px) {
-  .roof-tune-up-page .hero .split { grid-template-columns: 1fr; }
-  .roof-tune-up-page .photo-card { max-width: 650px; }
-  .roof-tune-up-page .photo-card img { aspect-ratio: 16/10; }
+  .roof-tune-up-page .tuneup-hero__content { grid-template-columns: 1fr; }
+  .roof-tune-up-page .tuneup-offer { max-width: 650px; }
   .roof-tune-up-page .commercial-scope { grid-template-columns: repeat(2,1fr); }
 }
 @media (max-width: 680px) {
-  .roof-tune-up-page .hero { min-height: auto; padding: 72px 14px 84px; }
-  .roof-tune-up-page .hero h1 { font-size: clamp(2.7rem,12vw,3.7rem); }
-  .roof-tune-up-page .hero .cta { flex-direction: column; }
-  .roof-tune-up-page .hero .btn { width: 100%; }
+  .roof-tune-up-page .tuneup-hero { min-height: 620px; }
+  .roof-tune-up-page .tuneup-hero > img { object-position: 62% center; }
+  .roof-tune-up-page .tuneup-hero__content { padding-top: 76px; padding-bottom: 82px; }
+  .roof-tune-up-page .tuneup-hero__copy h1 { font-size: clamp(2.65rem,12vw,3.7rem); }
+  .roof-tune-up-page .tuneup-hero__copy > p:not(.tuneup-hero__fine) { font-size: .9rem; line-height: 1.65; }
+  .roof-tune-up-page .tuneup-offer { padding: 29px 24px 27px; }
   .roof-tune-up-page .pillnav { top: 76px; width: calc(100% - 20px); margin-top: -25px; }
   .roof-tune-up-page .section { width: min(100% - 28px,1180px); padding: 68px 0; }
   .roof-tune-up-page .section > h2,.roof-tune-up-page .sa-head h2 { font-size: clamp(2.2rem,10vw,3.05rem); }

--- a/services/roof-repairs/roof-tune-up/index.html
+++ b/services/roof-repairs/roof-tune-up/index.html
@@ -71,33 +71,43 @@
   <div data-include="/components/header-section.html"></div>
 
   <main id="main-content" class="page premium-page">
-    <!-- ===== HERO (split) ===== -->
-    <section class="hero" aria-label="Roof Tune-Up">
-      <div class="eyebrow">
-        <span class="chip">Maintenance</span>
-        <span class="chip">Tune-Up</span>
-        <span class="chip">Photo Summary</span>
-      </div>
-      <div class="split">
-        <div>
-          <h1 style="margin:0 0 .5rem">Roof Tune-Up — Prevent Leaks, Extend Roof Life</h1>
-          <p class="lede">Stop small issues before they become costly leaks. Our roof tune-up includes targeted maintenance, sealant touch-ups, and debris clearing—ideal for <strong>Escondido</strong>, <strong>San Diego</strong>, and <strong>Temecula</strong>.</p>
-          <div class="cta">
-            <a class="btn btn-primary" href="#estimate" aria-label="Request a free estimate for a roof tune-up">Request Free Estimate</a>
-            <a class="btn btn-outline" href="#what">What’s Included</a>
+    <section class="interior-hero tuneup-hero" aria-label="Roof Tune-Up">
+      <img src="/images/hvac-penetrations-before-after-1440.webp"
+           srcset="/images/hvac-penetrations-before-after-480.webp 480w,
+                   /images/hvac-penetrations-before-after-768.webp 768w,
+                   /images/hvac-penetrations-before-after-1024.webp 1024w,
+                   /images/hvac-penetrations-before-after-1440.webp 1440w"
+           sizes="100vw" alt="HVAC roof penetrations before and after professional tune-up detailing"
+           width="1440" height="900" fetchpriority="high">
+      <span class="interior-hero__shade" aria-hidden="true"></span>
+      <div class="shell interior-hero__content tuneup-hero__content">
+        <div class="tuneup-hero__copy">
+          <span class="eyebrow eyebrow--light">Condition-based roof maintenance</span>
+          <h1>Roof tune-ups in San Diego, North County &amp; Temecula.</h1>
+          <p>Targeted maintenance for serviceable commercial, tile and limited shingle roofs—focused on vulnerable details, drainage, minor repairs and clear photo documentation.</p>
+          <div class="interior-hero__actions">
+            <a class="button button--orange" href="#estimate">Request a Roof Evaluation <span aria-hidden="true">→</span></a>
+            <a class="button button--glass" href="#what">See What’s Included</a>
+            <a class="button button--glass" href="#commercial">Compare Tune-Up Options</a>
           </div>
+          <p class="tuneup-hero__fine">A tune-up preserves serviceable roof areas; it cannot restore broadly failed underlayment, membrane or shingles.</p>
         </div>
-        <div class="photo-card">
-  <img
-    src="../../../images/hvac-penetrations-before-after-1024.webp"
-    srcset="../../../images/hvac-penetrations-before-after-480.webp 480w,
-            ../../../images/hvac-penetrations-before-after-768.webp 768w,
-            ../../../images/hvac-penetrations-before-after-1024.webp 1024w,
-            ../../../images/hvac-penetrations-before-after-1440.webp 1440w"
-    sizes="(max-width: 900px) 100vw, 50vw"
-    alt="HVAC roof penetrations—before and after sealing during tune-up"
-    loading="eager" decoding="async" fetchpriority="high" />
-</div>
+        <aside class="tuneup-offer" aria-label="Roof tune-up categories">
+          <span class="tuneup-offer__label">Maintenance built around the roof</span>
+          <strong><span>3</span> systems</strong>
+          <h2>one condition-based approach</h2>
+          <p>Commercial low-slope roofs, tile roofs and limited repairable shingle conditions each require different materials and decisions.</p>
+          <a class="text-link" href="#commercial">Explore the maintenance paths <span aria-hidden="true">→</span></a>
+        </aside>
+      </div>
+    </section>
+
+    <section class="interior-trust" aria-label="Roof tune-up highlights">
+      <div class="shell interior-trust__grid">
+        <span><b>Condition based</b><small>Maintenance matched to roof condition</small></span>
+        <span><b>Photo documented</b><small>Clear findings and completed details</small></span>
+        <span><b>Multiple roof systems</b><small>Commercial, tile and limited shingle</small></span>
+        <span><b>Local evaluation</b><small>San Diego County and Temecula Valley</small></span>
       </div>
     </section>
 

--- a/services/roof-repairs/roof-tune-up/index.html
+++ b/services/roof-repairs/roof-tune-up/index.html
@@ -370,10 +370,12 @@
 
     <!-- ===== ESTIMATE FORM (Roof Tune-Up) ===== -->
     <section id="estimate" class="section estimate-form-section">
+      <div class="estimate-form-heading">
+        <span>Secure estimate request</span>
+        <h2>Tell us what your roof needs.</h2>
+        <p>Share the property address and any visible concerns. Photos help us understand the roof before we contact you.</p>
+      </div>
       <div class="estimate-form-block" data-include="/components/estimate-form.html"></div>
-      <p class="form-disclaimer">
-        <em>*Free estimates exclude real-estate transaction inspections/reports. If you’re a buyer/seller or agent, please see our Real Estate Services.</em>
-      </p>
     </section>
 
     <!-- Full-width CTA band inside container -->

--- a/services/roof-repairs/roof-tune-up/index.html
+++ b/services/roof-repairs/roof-tune-up/index.html
@@ -18,103 +18,10 @@
   <meta property="og:image:alt" content="Commercial roof drains after professional cleaning and sealant detailing"/>
   <meta name="twitter:card" content="summary_large_image"/>
 
-  <!-- Shared CSS (match gutters page order) -->
-  <link rel="preload" href="/css/base.css" as="style"/>
-  <link rel="preload" href="/css/header.css" as="style"/>
-  <link rel="preload" href="/css/ui.css" as="style"/>
-  <link rel="stylesheet" href="/css/base.css"/>
-  <link rel="stylesheet" href="/css/header.css"/>
-  <link rel="stylesheet" href="/css/ui.css"/>
-  <link rel="stylesheet" href="/css/footer.css"/>
-  <!-- Form CSS -->
+  <link rel="preload" as="image" href="/images/hvac-penetrations-before-after-1440.webp"/>
+  <link rel="stylesheet" href="/css/zenith-premium-exact.css?v=exact-premium-3"/>
   <link rel="stylesheet" href="/css/estimate-form.css"/>
-
-  <!-- Page-scope polish (same vibe as gutters page) -->
-  <style>
-    :root{ --zenith-navy:#072e59; --zenith-orange:#f7941d; }
-    html { scroll-behavior: smooth; }
-
-    .page .hero{
-      background: linear-gradient(135deg,#f8fafc 0%, #eef6ff 100%);
-      border: 1px solid var(--ui-line);
-      border-radius: 18px;
-      padding: clamp(18px, 3vw, 28px);
-      box-shadow: 0 14px 34px rgba(2,12,32,.08);
-    }
-    .page .hero .eyebrow{ display:flex; flex-wrap:wrap; gap:8px; margin:0 0 .6rem; }
-    .page .hero .eyebrow .chip{ background:#fff; font-weight:800; }
-    .page .hero .split{ align-items:center; }
-    .page .hero .media{
-      border-radius:14px; overflow:hidden; border:1px solid var(--ui-line);
-      background:#fff; box-shadow: var(--ui-shadow); transform: translateZ(0);
-    }
-    .page .hero .media::before{
-      content:""; display:block; aspect-ratio:16/10;
-      background: linear-gradient(135deg, rgba(7,46,89,.08), rgba(247,148,29,.08));
-    }
-
-    .page h2{ margin-bottom:.4rem; }
-    .page .section .lede-narrow{ max-width:68ch; color:#475569; }
-
-    .page .card.hoverable{ will-change: transform, box-shadow; }
-    .page .card.hoverable:hover{ transform: translateY(-3px); }
-
-    .page .mini-list{ margin:.5rem 0 0 .95rem; color:#334155; }
-    .page .mini-list li{ margin:.25rem 0; }
-
-    .page .center-actions{ display:flex; gap:10px; justify-content:center; flex-wrap:wrap; margin-top:.6rem; }
-
-    .page .cta-strip{
-      background:#072e59; color:#fff; border-radius:16px;
-      padding:16px; display:flex; flex-wrap:wrap; gap:12px; align-items:center;
-      box-shadow:0 14px 34px rgba(2,12,32,.12);
-    }
-    .page .cta-strip .btn{ background:#f7941d; color:#0b0b0b; }
-    .page .cta-strip .btn:hover{ transform:translateY(-2px); }
-
-    .commercial-tuneup,.tile-tuneup,.shingle-tuneup{ border-top:5px solid var(--zenith-orange); }
-    .commercial-tuneup .section-kicker,.tile-tuneup .section-kicker,.shingle-tuneup .section-kicker{
-      color:#c75f00; font-size:.8rem; font-weight:900; letter-spacing:.09em;
-      margin:0 0 .35rem; text-transform:uppercase;
-    }
-    .commercial-tuneup .intro{
-      max-width:78ch;
-      margin-left:auto;
-      margin-right:auto;
-    }
-    .commercial-scope{
-      display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px;
-      margin:1.2rem 0;
-    }
-    .commercial-scope article{
-      border:1px solid #d9e3ef; border-radius:14px; background:#f8fbff; padding:16px;
-    }
-    .commercial-scope h3{ color:var(--zenith-navy); font-size:1.05rem; margin:0 0 .35rem; }
-    .commercial-scope p{ color:#475569; margin:0; }
-    .project-proof{
-      display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:14px; margin:1.25rem 0;
-    }
-    .project-proof figure{
-      background:#fff; border:1px solid #d9e3ef; border-radius:14px; margin:0;
-      overflow:hidden; box-shadow:0 10px 26px rgba(2,12,32,.08);
-    }
-    .project-proof img{ display:block; width:100%; aspect-ratio:4/3; object-fit:cover; }
-    .project-proof figcaption{ color:#334155; font-size:.94rem; line-height:1.45; padding:12px 14px 14px; }
-    .project-proof figcaption strong{ color:var(--zenith-navy); display:block; margin-bottom:.2rem; }
-    .decision-grid{
-      display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:12px; margin-top:1rem;
-    }
-    .decision-grid article{ border:1px solid #d9e3ef; border-radius:14px; padding:16px; }
-    .decision-grid h3{ color:var(--zenith-navy); font-size:1.05rem; margin:0 0 .35rem; }
-    .decision-grid p{ color:#475569; margin:0; }
-    .field-note{
-      background:#fff7ed; border-left:4px solid var(--zenith-orange); border-radius:10px;
-      color:#6b3b10; margin:1rem 0; padding:14px 16px;
-    }
-    @media (max-width:760px){
-      .commercial-scope,.project-proof,.decision-grid{ grid-template-columns:1fr; }
-    }
-  </style>
+  <link rel="stylesheet" href="/css/roof-tune-up-premium.css?v=1"/>
 
   <!-- JSON-LD: Service + FAQ -->
   <script type="application/ld+json">
@@ -158,13 +65,12 @@
     ]
   }
   </script>
-  <link rel="stylesheet" href="/css/landing-theme-preview.css?v=sitewide-2">
 </head>
-<body>
+<body class="roof-tune-up-page">
   <!-- Header include -->
   <div data-include="/components/header-section.html"></div>
 
-  <main id="top" class="page">
+  <main id="main-content" class="page premium-page">
     <!-- ===== HERO (split) ===== -->
     <section class="hero" aria-label="Roof Tune-Up">
       <div class="eyebrow">
@@ -226,7 +132,7 @@
           </ul>
         </div>
       </div>
-      <p class="section lede-narrow" style="margin:0;">Perfect for annual upkeep or pre-storm prep across North County San Diego, Temecula Valley, and greater San Diego County.</p>
+      <p class="lede-narrow" style="margin-top:24px;">Perfect for annual upkeep or pre-storm prep across North County San Diego, Temecula Valley, and greater San Diego County.</p>
       <div class="center-actions">
         <a class="btn btn-primary" href="#estimate">Request Free Estimate</a>
       </div>
@@ -379,7 +285,7 @@
       <h3>Inspection, Documentation &amp; the Right Next Step</h3>
       <div class="decision-grid">
         <article><h3>Isolated maintenance</h3><p>Best for a small, clearly defined condition on an otherwise serviceable roof with repairable surrounding shingles.</p></article>
-        <article><h3>Wind-damage evaluation</h3><p>We can document visible roof conditions and explain the roofing scope. Homeowners remain responsible for claim decisions and should contact their insurer for coverage questions.</p></article>
+        <article><h3>Wind-damage evaluation</h3><p>We can document visible roof conditions and explain the roofing scope. Property owners remain responsible for claim decisions and should contact their insurer for coverage questions.</p></article>
         <article><h3>Replacement evaluation</h3><p>Recommended when damage is widespread, shingles are too brittle or bonded to repair, matching products are unavailable, or the remaining roof life is limited.</p></article>
       </div>
       <p class="intro" style="margin-top:1rem;">Some shingle evaluations are requested for real-estate transactions or insurance matters. Those inspections and reports are separate from a standard free replacement estimate; see our <a href="/services/real-estate/">Real Estate Roofing Services</a> for transaction-specific work.</p>


### PR DESCRIPTION
## What changed

- Rebuilt `/services/roof-repairs/roof-tune-up/` using the Financing page's full-width premium geometry.
- Added a full-bleed image hero, glass-framed project proof, sticky section navigation, premium maintenance scope cards, real-project galleries, decision grids, FAQs, service areas, and lead-focused estimate/CTA sections.
- Added one scoped stylesheet at `/css/roof-tune-up-premium.css`.
- Removed the legacy global body gutter and old standalone theme.

## Preserved

- Commercial, tile, and limited shingle tune-up content and technical guidance.
- Every real project image, caption, internal service link, and service-area detail.
- Estimate-form include, field configuration, locked service, hidden campaign fields, validation, reCAPTCHA, and submission script.
- Real-estate transaction disclaimer, canonical URL, metadata, and all three JSON-LD blocks.
- Shared header, footer, and permanent mobile navigation.

## Validation

- All JSON-LD parses successfully.
- Inline JavaScript compiles.
- No duplicate IDs or whitespace errors.
- All hero, gallery, form, and shared assets exist.
- Responsive desktop, tablet, mobile, focus, and reduced-motion styles are included.