### PR TITLE
Align TPO page with Zenith premium design system

### DIFF
--- a/css/tpo-premium.css
+++ b/css/tpo-premium.css
@@ -1,24 +1,379 @@
-.tpo-page{background:#fff;color:var(--ink-950)}
-.tpo-page .shell{width:min(1180px,calc(100% - 40px));margin-inline:auto}
-.tpo-hero{min-height:720px;position:relative;display:grid;align-items:center;overflow:hidden;background:var(--navy-950)}
-.tpo-hero>img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:center 58%}
-.tpo-hero .interior-hero__shade{position:absolute;inset:0;background:linear-gradient(90deg,rgba(3,26,48,.98) 0%,rgba(3,26,48,.88) 47%,rgba(3,26,48,.52) 100%),linear-gradient(0deg,rgba(3,26,48,.38),transparent 55%)}
-.tpo-hero__content{position:relative;z-index:1;display:grid;grid-template-columns:minmax(0,1.4fr) minmax(290px,.6fr);gap:72px;align-items:center;padding-block:110px}
-.tpo-hero__copy{max-width:760px}.tpo-hero h1{margin:20px 0 22px;color:#fff;font-size:clamp(3.1rem,6vw,6.2rem);line-height:.93;letter-spacing:-.065em}.tpo-hero__copy>p{max-width:700px;color:rgba(255,255,255,.8);font-size:clamp(1.08rem,1.6vw,1.35rem);line-height:1.65}.tpo-hero .interior-hero__actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:34px}
-.tpo-project-card{padding:34px;border:1px solid rgba(255,255,255,.28);border-radius:30px;background:linear-gradient(145deg,rgba(255,255,255,.17),rgba(255,255,255,.08));box-shadow:0 28px 70px rgba(0,0,0,.2);backdrop-filter:blur(18px);color:#fff}.tpo-project-card__label{display:inline-flex;padding:9px 13px;border:1px solid rgba(255,130,0,.45);border-radius:999px;background:rgba(255,130,0,.13);color:#ffd5aa;font-size:.72rem;font-weight:900;letter-spacing:.12em;text-transform:uppercase}.tpo-project-card strong{display:block;margin-top:30px;color:var(--orange-500);font-size:5.5rem;line-height:.85;letter-spacing:-.08em}.tpo-project-card strong span{font-size:1.1rem;letter-spacing:0}.tpo-project-card h2{margin:14px 0 10px;color:#fff;font-size:1.55rem}.tpo-project-card p{color:rgba(255,255,255,.72);line-height:1.65}.tpo-project-card .text-link{display:inline-flex;margin-top:18px;color:#ffb968;font-weight:800;text-decoration:none}
-.interior-trust{position:relative;z-index:2;background:#fff;border-bottom:1px solid #dfe7ef}.interior-trust__grid{display:grid;grid-template-columns:repeat(4,1fr)}.interior-trust__grid>span{display:flex;min-height:104px;flex-direction:column;justify-content:center;padding:22px 28px;border-right:1px solid #dfe7ef}.interior-trust__grid>span:first-child{border-left:1px solid #dfe7ef}.interior-trust b{font-size:.96rem}.interior-trust small{margin-top:6px;color:var(--ink-500);line-height:1.4}
-.tpo-section{padding:clamp(76px,8vw,124px) 0}.tpo-section--mist{background:var(--mist)}.tpo-section--navy{background:linear-gradient(145deg,var(--navy-950),var(--navy-900));color:#fff}.tpo-split{display:grid;grid-template-columns:minmax(0,1fr) minmax(360px,.82fr);gap:clamp(48px,7vw,96px);align-items:center}.tpo-split--reverse .tpo-copy{order:2}.tpo-copy h2,.tpo-section-heading h2,.tpo-faq-copy h2,.tpo-estimate-copy h2{margin:16px 0 20px;font-size:clamp(2.55rem,5vw,4.8rem);line-height:1;letter-spacing:-.055em}.tpo-copy p,.tpo-section-heading>p,.tpo-faq-copy p,.tpo-estimate-copy p{color:var(--ink-700);font-size:1.06rem;line-height:1.8}.tpo-copy .lead,.tpo-estimate-copy .lead{font-size:1.22rem}.tpo-note{display:flex;gap:16px;margin-top:30px;padding:22px 24px;border-left:4px solid var(--orange-500);border-radius:0 18px 18px 0;background:var(--orange-100)}.tpo-note>span{display:grid;width:30px;height:30px;flex:0 0 30px;place-items:center;border-radius:50%;background:var(--orange-500);color:#111;font-weight:900}.tpo-note p{margin:0;color:#633817;font-size:.94rem;line-height:1.65}
-.tpo-photo-card{margin:0;overflow:hidden;border:1px solid #dfe7ef;border-radius:28px;background:#fff;box-shadow:0 24px 60px rgba(3,26,48,.13)}.tpo-photo-card img{display:block;width:100%;aspect-ratio:4/3;object-fit:cover}.tpo-photo-card figcaption{padding:18px 22px;color:var(--ink-700);font-size:.9rem;line-height:1.55}.tpo-photo-card figcaption b{color:var(--orange-600)}
-.tpo-check-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:18px;margin-top:70px}.tpo-check-grid article{padding:30px 26px;border:1px solid #dfe7ef;border-radius:22px;background:#fff;box-shadow:0 14px 34px rgba(3,26,48,.07);transition:transform .25s ease,border-color .25s ease}.tpo-check-grid article:hover{transform:translateY(-4px);border-color:rgba(255,130,0,.55)}.tpo-check-grid article>span{color:var(--orange-600);font-size:.75rem;font-weight:900;letter-spacing:.12em}.tpo-check-grid h3{margin:18px 0 10px;font-size:1.13rem}.tpo-check-grid p{margin:0;color:var(--ink-500);line-height:1.65}
-.tpo-section-heading{display:grid;grid-template-columns:1.2fr .8fr;gap:70px;align-items:end;margin-bottom:54px}.tpo-section-heading h2{margin-bottom:0}.tpo-section-heading>p{margin:0}.tpo-section-heading--light h2{color:#fff}.tpo-section-heading--light>p{color:rgba(255,255,255,.68)}
-.tpo-methods{display:grid;grid-template-columns:1fr 1fr;gap:22px}.tpo-method{padding:40px;border:1px solid rgba(255,255,255,.15);border-radius:28px;background:rgba(255,255,255,.07);box-shadow:0 22px 55px rgba(0,0,0,.14)}.tpo-method__number{color:var(--orange-500);font-size:.78rem;font-weight:900;letter-spacing:.15em}.tpo-method h3{margin:20px 0 16px;color:#fff;font-size:2rem}.tpo-method p,.tpo-method li{color:rgba(255,255,255,.73);line-height:1.7}.tpo-method ul{display:grid;gap:10px;margin:24px 0 0;padding-left:22px}.tpo-method li::marker{color:var(--orange-500)}.tpo-method-footnote{margin-top:22px;padding:20px 24px;border-radius:18px;background:rgba(255,255,255,.08);color:rgba(255,255,255,.72);line-height:1.6}.tpo-method-footnote strong{color:#fff}
-.tpo-case-grid{display:grid;grid-template-columns:minmax(0,.8fr) minmax(500px,1.2fr);gap:clamp(50px,7vw,90px);align-items:start}.tpo-detail-list{display:grid;gap:12px;margin-top:32px}.tpo-detail-list span{display:flex;justify-content:space-between;gap:22px;padding:16px 0;border-bottom:1px solid #dfe7ef}.tpo-detail-list b{font-size:.92rem}.tpo-detail-list small{max-width:260px;color:var(--ink-500);text-align:right;line-height:1.5}.tpo-process-photos,.tpo-residential-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}.tpo-process-photos figure,.tpo-residential-grid figure{margin:0;overflow:hidden;border:1px solid #dfe7ef;border-radius:20px;background:#fff;box-shadow:0 15px 35px rgba(3,26,48,.08)}.tpo-process-photos img,.tpo-residential-grid img{display:block;width:100%;aspect-ratio:4/3;object-fit:cover}.tpo-process-photos figcaption,.tpo-residential-grid figcaption{padding:13px 15px;color:var(--ink-500);font-size:.8rem;line-height:1.4}
-.tpo-checks{display:grid;gap:13px;margin:28px 0 34px;padding:0;list-style:none}.tpo-checks li{position:relative;padding-left:32px;color:var(--ink-700);line-height:1.6}.tpo-checks li::before{content:'✓';position:absolute;left:0;top:0;display:grid;width:22px;height:22px;place-items:center;border-radius:50%;background:var(--orange-500);color:#08182a;font-size:.75rem;font-weight:900}
-.tpo-detail-cards{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}.tpo-detail-cards article{padding:30px 26px;border:1px solid #dfe7ef;border-radius:22px;background:#fff;box-shadow:0 14px 34px rgba(3,26,48,.07)}.tpo-detail-cards article>span{display:grid;width:42px;height:42px;place-items:center;border-radius:14px;background:var(--orange-100);color:var(--orange-600);font-weight:900}.tpo-detail-cards h3{margin:22px 0 10px}.tpo-detail-cards p{margin:0;color:var(--ink-500);line-height:1.65}
-.tpo-copy--light h2{color:#fff}.tpo-copy--light p{color:rgba(255,255,255,.72)}.tpo-weld-steps{display:grid;grid-template-columns:1fr 1fr;gap:14px}.tpo-weld-steps span{display:flex;min-height:130px;flex-direction:column;justify-content:space-between;padding:24px;border:1px solid rgba(255,255,255,.14);border-radius:20px;background:rgba(255,255,255,.07)}.tpo-weld-steps b{color:var(--orange-500);font-size:1.6rem}.tpo-weld-steps small{color:#fff;font-size:.95rem;line-height:1.45}
-.tpo-residential-grid figure:first-child{margin-top:48px}.tpo-residential-grid figure:last-child{margin-bottom:48px}.tpo-process-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:0;padding:0;list-style:none}.tpo-process-grid li{padding:30px;border:1px solid #dfe7ef;border-radius:22px;background:#fff;box-shadow:0 14px 34px rgba(3,26,48,.06)}.tpo-process-grid span{color:var(--orange-600);font-size:.75rem;font-weight:900;letter-spacing:.12em}.tpo-process-grid h3{margin:18px 0 10px}.tpo-process-grid p{margin:0;color:var(--ink-500);line-height:1.65}
-.tpo-faq-layout{display:grid;grid-template-columns:.72fr 1.28fr;gap:80px;align-items:start}.tpo-faq-copy{position:sticky;top:150px}.tpo-accordions{display:grid;gap:12px}.tpo-accordions details{overflow:hidden;border:1px solid #dfe7ef;border-radius:18px;background:#fff;box-shadow:0 10px 28px rgba(3,26,48,.06)}.tpo-accordions summary{display:flex;min-height:72px;cursor:pointer;align-items:center;justify-content:space-between;gap:20px;padding:20px 24px;color:var(--ink-950);font-weight:800;list-style:none}.tpo-accordions summary::-webkit-details-marker{display:none}.tpo-accordions summary span{color:var(--orange-600);font-size:1.4rem}.tpo-accordions details[open] summary span{transform:rotate(45deg)}.tpo-accordions details p{margin:0;padding:0 24px 24px;color:var(--ink-700);line-height:1.7}
-.tpo-estimate{background:linear-gradient(180deg,var(--mist),#eaf0f5)}.tpo-estimate-layout{display:grid;grid-template-columns:.72fr 1.28fr;gap:70px;align-items:start}.tpo-form-card{overflow:hidden;border:1px solid #dfe7ef;border-radius:28px;background:#fff;box-shadow:0 28px 70px rgba(3,26,48,.13)}.tpo-form-card__head{padding:30px 34px 22px;border-bottom:1px solid #e4ebf1}.tpo-form-card__head>span{color:var(--orange-600);font-size:.72rem;font-weight:900;letter-spacing:.13em;text-transform:uppercase}.tpo-form-card__head h3{margin:10px 0 7px;font-size:1.75rem}.tpo-form-card__head p{margin:0;color:var(--ink-500);line-height:1.55}.tpo-form-card [data-include]{padding:28px 34px}.tpo-form-note{margin:0 34px 34px;padding:16px 18px;border-left:3px solid var(--orange-500);border-radius:0 12px 12px 0;background:var(--orange-100);color:#6b401b;font-size:.86rem;line-height:1.55}.tpo-form-note a{color:var(--navy-800);font-weight:800}.tpo-final-cta{padding:66px 0;background:linear-gradient(120deg,var(--navy-950),var(--navy-800));color:#fff}.tpo-final-cta .shell{display:flex;align-items:center;justify-content:space-between;gap:50px}.tpo-final-cta h2{max-width:790px;margin:12px 0 0;color:#fff;font-size:clamp(2rem,4vw,3.8rem);line-height:1.04;letter-spacing:-.045em}.tpo-final-cta__actions{display:flex;flex:0 0 auto;gap:12px;flex-wrap:wrap}
-@media(max-width:980px){.tpo-hero__content,.tpo-split,.tpo-case-grid,.tpo-faq-layout,.tpo-estimate-layout{grid-template-columns:1fr}.tpo-hero__content{gap:38px}.tpo-project-card{max-width:520px}.tpo-split--reverse .tpo-copy{order:0}.tpo-check-grid,.tpo-detail-cards{grid-template-columns:1fr 1fr}.tpo-section-heading{grid-template-columns:1fr;gap:18px}.tpo-case-grid{gap:48px}.tpo-faq-copy{position:static}.tpo-final-cta .shell{align-items:flex-start;flex-direction:column}.tpo-process-grid{grid-template-columns:1fr 1fr}}
-@media(max-width:720px){.tpo-page .shell{width:min(100% - 28px,1180px)}.tpo-hero{min-height:auto}.tpo-hero__content{padding-block:78px}.tpo-hero h1{font-size:clamp(2.85rem,14vw,4.3rem)}.tpo-project-card{padding:26px}.tpo-project-card strong{font-size:4.6rem}.interior-trust__grid{grid-template-columns:1fr 1fr}.interior-trust__grid>span,.interior-trust__grid>span:first-child{min-height:94px;padding:18px;border-left:0;border-right:0;border-bottom:1px solid #dfe7ef}.interior-trust__grid>span:nth-child(odd){border-right:1px solid #dfe7ef}.tpo-section{padding:72px 0}.tpo-copy h2,.tpo-section-heading h2,.tpo-faq-copy h2,.tpo-estimate-copy h2{font-size:clamp(2.3rem,11vw,3.45rem)}.tpo-check-grid,.tpo-methods,.tpo-detail-cards,.tpo-process-grid,.tpo-weld-steps{grid-template-columns:1fr}.tpo-method{padding:30px}.tpo-process-photos,.tpo-residential-grid{gap:10px}.tpo-process-photos figcaption,.tpo-residential-grid figcaption{display:none}.tpo-detail-list span{align-items:flex-start;flex-direction:column;gap:5px}.tpo-detail-list small{max-width:none;text-align:left}.tpo-residential-grid figure:first-child{margin-top:24px}.tpo-residential-grid figure:last-child{margin-bottom:24px}.tpo-form-card__head,.tpo-form-card [data-include]{padding-left:20px;padding-right:20px}.tpo-form-note{margin-left:20px;margin-right:20px}.tpo-final-cta__actions{width:100%;flex-direction:column}.tpo-final-cta__actions .button{justify-content:center;width:100%}}
-@media(prefers-reduced-motion:reduce){.tpo-check-grid article{transition:none}.tpo-check-grid article:hover{transform:none}}
+.tpo-page {
+  width: 100%;
+  max-width: none;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden;
+  background: var(--mist);
+  color: var(--ink-950);
+}
+
+.tpo-page .shell {
+  width: min(100% - 36px, 1180px);
+  margin-inline: auto;
+}
+
+.tpo-hero {
+  position: relative;
+  display: grid;
+  min-height: 720px;
+  align-items: center;
+  overflow: hidden;
+  background: var(--navy-950);
+}
+
+.tpo-hero > img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 58%;
+}
+
+.tpo-hero .interior-hero__shade {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(3, 26, 48, .98) 0%, rgba(3, 26, 48, .9) 48%, rgba(3, 26, 48, .55) 100%),
+    linear-gradient(0deg, rgba(3, 26, 48, .42), transparent 58%);
+}
+
+.tpo-hero__content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(300px, .58fr);
+  gap: clamp(42px, 6vw, 78px);
+  align-items: center;
+  padding-block: 104px;
+}
+
+.tpo-hero__copy { max-width: 760px; }
+
+.tpo-hero h1 {
+  max-width: 760px;
+  margin: 20px 0 22px;
+  color: #fff;
+  font-size: clamp(3rem, 5.4vw, 5.3rem);
+  line-height: .98;
+  letter-spacing: -.055em;
+}
+
+.tpo-hero__copy > p {
+  max-width: 690px;
+  color: rgba(255, 255, 255, .8);
+  font-size: clamp(1.04rem, 1.5vw, 1.28rem);
+  line-height: 1.65;
+}
+
+.tpo-hero .interior-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.tpo-project-card {
+  max-width: 430px;
+  padding: 30px;
+  border: 1px solid rgba(255, 255, 255, .28);
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, .16), rgba(255, 255, 255, .08));
+  box-shadow: 0 24px 60px rgba(0, 0, 0, .2);
+  backdrop-filter: blur(16px);
+  color: #fff;
+}
+
+.tpo-project-card__label {
+  display: inline-flex;
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 130, 0, .45);
+  border-radius: 999px;
+  background: rgba(255, 130, 0, .13);
+  color: #ffd5aa;
+  font-size: .7rem;
+  font-weight: 900;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.tpo-project-card strong {
+  display: block;
+  margin-top: 24px;
+  color: var(--orange-500);
+  font-size: 3.8rem;
+  line-height: .95;
+  letter-spacing: -.06em;
+}
+
+.tpo-project-card strong span {
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+.tpo-project-card h2 {
+  margin: 14px 0 10px;
+  color: #fff;
+  font-size: 1.45rem;
+}
+
+.tpo-project-card p {
+  margin: 0;
+  color: rgba(255, 255, 255, .74);
+  line-height: 1.6;
+}
+
+.tpo-project-card .text-link {
+  display: inline-flex;
+  margin-top: 18px;
+  color: #ffb968;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.interior-trust {
+  position: relative;
+  z-index: 2;
+  border-bottom: 1px solid #dfe7ef;
+  background: #fff;
+}
+
+.interior-trust__grid { display: grid; grid-template-columns: repeat(4, 1fr); }
+.interior-trust__grid > span { display: flex; min-height: 102px; flex-direction: column; justify-content: center; padding: 22px 28px; border-right: 1px solid #dfe7ef; }
+.interior-trust__grid > span:first-child { border-left: 1px solid #dfe7ef; }
+.interior-trust b { font-size: .96rem; }
+.interior-trust small { margin-top: 6px; color: var(--ink-500); line-height: 1.4; }
+
+.tpo-section { padding: 88px 0; background: #fff; }
+.tpo-section--mist, .tpo-faq, .tpo-estimate { background: var(--mist); }
+.tpo-section--navy { background: linear-gradient(145deg, var(--navy-950), var(--navy-900)); color: #fff; }
+
+.tpo-split,
+.tpo-case-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, .85fr);
+  gap: clamp(44px, 6vw, 70px);
+  align-items: center;
+}
+
+.tpo-case-grid { grid-template-columns: minmax(0, .9fr) minmax(0, 1.1fr); align-items: start; }
+.tpo-split--reverse .tpo-copy { order: 2; }
+
+.tpo-copy h2,
+.tpo-section-heading h2,
+.tpo-faq-copy h2,
+.tpo-estimate-copy h2 {
+  margin: 14px 0 18px;
+  font-size: clamp(2.2rem, 4.7vw, 4.15rem);
+  line-height: 1.02;
+  letter-spacing: -.05em;
+}
+
+.tpo-copy p,
+.tpo-section-heading > p,
+.tpo-faq-copy p,
+.tpo-estimate-copy p {
+  color: var(--ink-700);
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.tpo-copy .lead, .tpo-estimate-copy .lead { font-size: 1.14rem; }
+
+.tpo-note {
+  display: flex;
+  gap: 14px;
+  margin-top: 28px;
+  padding: 20px 22px;
+  border-left: 4px solid var(--orange-500);
+  border-radius: 0 16px 16px 0;
+  background: var(--orange-100);
+}
+
+.tpo-note > span { display: grid; width: 28px; height: 28px; flex: 0 0 28px; place-items: center; border-radius: 50%; background: var(--orange-500); color: #111; font-weight: 900; }
+.tpo-note p { margin: 0; color: #633817; font-size: .92rem; line-height: 1.6; }
+
+.tpo-photo-card {
+  max-width: 520px;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid #dfe7ef;
+  border-radius: 22px;
+  background: #fff;
+  box-shadow: 0 20px 50px rgba(3, 26, 48, .12);
+}
+
+.tpo-photo-card img {
+  display: block;
+  width: 100%;
+  height: clamp(250px, 30vw, 360px);
+  max-height: 360px;
+  object-fit: cover;
+}
+
+.tpo-photo-card figcaption { padding: 16px 20px; color: var(--ink-700); font-size: .88rem; line-height: 1.5; }
+.tpo-photo-card figcaption b { color: var(--orange-600); }
+
+.tpo-check-grid,
+.tpo-detail-cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+  margin-top: 54px;
+}
+
+.tpo-check-grid article,
+.tpo-detail-cards article,
+.tpo-process-grid li {
+  padding: 28px 24px;
+  border: 1px solid #dfe7ef;
+  border-radius: 20px;
+  background: #fff;
+  box-shadow: 0 14px 34px rgba(3, 26, 48, .07);
+  transition: transform .25s ease, border-color .25s ease, box-shadow .25s ease;
+}
+
+.tpo-check-grid article:hover,
+.tpo-detail-cards article:hover,
+.tpo-process-grid li:hover { transform: translateY(-4px); border-color: rgba(255, 130, 0, .55); box-shadow: 0 20px 40px rgba(3, 26, 48, .11); }
+.tpo-check-grid article > span, .tpo-process-grid span { color: var(--orange-600); font-size: .74rem; font-weight: 900; letter-spacing: .12em; }
+.tpo-check-grid h3, .tpo-process-grid h3 { margin: 17px 0 9px; font-size: 1.12rem; }
+.tpo-check-grid p, .tpo-detail-cards p, .tpo-process-grid p { margin: 0; color: var(--ink-500); line-height: 1.62; }
+
+.tpo-section-heading { display: grid; grid-template-columns: 1.1fr .9fr; gap: 56px; align-items: end; margin-bottom: 44px; }
+.tpo-section-heading h2 { margin-bottom: 0; }
+.tpo-section-heading > p { margin: 0; }
+.tpo-section-heading--light h2 { color: #fff; }
+.tpo-section-heading--light > p { color: rgba(255, 255, 255, .7); }
+
+.tpo-methods { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+.tpo-method { padding: 34px; border: 1px solid rgba(255, 255, 255, .15); border-radius: 24px; background: rgba(255, 255, 255, .07); box-shadow: 0 18px 45px rgba(0, 0, 0, .14); }
+.tpo-method__number { color: var(--orange-500); font-size: .76rem; font-weight: 900; letter-spacing: .15em; }
+.tpo-method h3 { margin: 18px 0 14px; color: #fff; font-size: 1.75rem; }
+.tpo-method p, .tpo-method li { color: rgba(255, 255, 255, .74); line-height: 1.65; }
+.tpo-method ul { display: grid; gap: 9px; margin: 22px 0 0; padding-left: 22px; }
+.tpo-method li::marker { color: var(--orange-500); }
+.tpo-method-footnote { margin-top: 20px; padding: 18px 22px; border-radius: 16px; background: rgba(255, 255, 255, .08); color: rgba(255, 255, 255, .74); line-height: 1.6; }
+.tpo-method-footnote strong { color: #fff; }
+
+.tpo-detail-list { display: grid; gap: 10px; margin-top: 28px; }
+.tpo-detail-list span { display: flex; justify-content: space-between; gap: 20px; padding: 14px 0; border-bottom: 1px solid #dfe7ef; }
+.tpo-detail-list b { font-size: .9rem; }
+.tpo-detail-list small { max-width: 270px; color: var(--ink-500); text-align: right; line-height: 1.5; }
+
+.tpo-process-photos,
+.tpo-residential-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+
+.tpo-process-photos figure,
+.tpo-residential-grid figure { margin: 0; overflow: hidden; border: 1px solid #dfe7ef; border-radius: 18px; background: #fff; box-shadow: 0 14px 32px rgba(3, 26, 48, .08); }
+
+.tpo-process-photos img,
+.tpo-residential-grid img { display: block; width: 100%; height: 220px; object-fit: cover; }
+.tpo-process-photos figcaption, .tpo-residential-grid figcaption { padding: 12px 14px; color: var(--ink-500); font-size: .78rem; line-height: 1.4; }
+
+.tpo-checks { display: grid; gap: 12px; margin: 26px 0 32px; padding: 0; list-style: none; }
+.tpo-checks li { position: relative; padding-left: 31px; color: var(--ink-700); line-height: 1.6; }
+.tpo-checks li::before { content: '✓'; position: absolute; left: 0; top: 1px; display: grid; width: 22px; height: 22px; place-items: center; border-radius: 50%; background: var(--orange-500); color: #08182a; font-size: .75rem; font-weight: 900; }
+
+.tpo-detail-cards { margin-top: 0; }
+.tpo-detail-cards article > span { display: grid; width: 42px; height: 42px; place-items: center; border-radius: 13px; background: var(--orange-100); color: var(--orange-600); font-weight: 900; }
+.tpo-detail-cards h3 { margin: 20px 0 9px; }
+.tpo-copy--light h2 { color: #fff; }
+.tpo-copy--light p { color: rgba(255, 255, 255, .74); }
+
+.tpo-weld-steps { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.tpo-weld-steps span { display: flex; min-height: 122px; flex-direction: column; justify-content: space-between; padding: 22px; border: 1px solid rgba(255, 255, 255, .14); border-radius: 18px; background: rgba(255, 255, 255, .07); }
+.tpo-weld-steps b { color: var(--orange-500); font-size: 1.5rem; }
+.tpo-weld-steps small { color: #fff; font-size: .92rem; line-height: 1.45; }
+
+.tpo-residential-grid figure:first-child,
+.tpo-residential-grid figure:last-child { margin: 0; }
+
+.tpo-process-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin: 0; padding: 0; list-style: none; }
+
+.tpo-faq-layout { max-width: 940px; }
+.tpo-faq-copy { max-width: 760px; margin-bottom: 34px; text-align: center; margin-inline: auto; }
+.tpo-accordions { display: grid; gap: 12px; }
+.tpo-accordions details { overflow: hidden; border: 1px solid #dfe7ef; border-radius: 16px; background: #fff; box-shadow: 0 10px 28px rgba(3, 26, 48, .06); }
+.tpo-accordions summary { display: flex; min-height: 68px; cursor: pointer; align-items: center; justify-content: space-between; gap: 20px; padding: 18px 22px; color: var(--ink-950); font-weight: 800; list-style: none; }
+.tpo-accordions summary::-webkit-details-marker { display: none; }
+.tpo-accordions summary span { color: var(--orange-600); font-size: 1.35rem; }
+.tpo-accordions details[open] summary span { transform: rotate(45deg); }
+.tpo-accordions details p { margin: 0; padding: 0 22px 22px; color: var(--ink-700); line-height: 1.7; }
+
+.tpo-estimate { background: linear-gradient(180deg, var(--mist), #eaf0f5); }
+.tpo-estimate-layout { display: grid; grid-template-columns: minmax(280px, .82fr) minmax(0, 1.18fr); gap: 52px; align-items: start; }
+.tpo-estimate-copy { padding-top: 26px; }
+.tpo-form-card { position: relative; overflow: hidden; border: 1px solid #dfe7ef; border-radius: 28px; background: #fff; box-shadow: 0 26px 64px rgba(3, 26, 48, .13); }
+.tpo-form-card::before { content: ''; position: absolute; inset: 0 0 auto; height: 4px; background: linear-gradient(90deg, var(--orange-500), #ffb458, #2484bd); }
+.tpo-form-card__head { padding: 32px 34px 22px; border-bottom: 1px solid #e4ebf1; }
+.tpo-form-card__head > span { color: var(--orange-600); font-size: .72rem; font-weight: 900; letter-spacing: .13em; text-transform: uppercase; }
+.tpo-form-card__head h3 { margin: 10px 0 7px; font-size: 1.72rem; }
+.tpo-form-card__head p { margin: 0; color: var(--ink-500); line-height: 1.55; }
+.tpo-form-card [data-include] { padding: 28px 34px; }
+.tpo-form-note { margin: 0 34px 34px; padding: 16px 18px; border-left: 3px solid var(--orange-500); border-radius: 0 12px 12px 0; background: var(--orange-100); color: #6b401b; font-size: .86rem; line-height: 1.55; }
+.tpo-form-note a { color: var(--navy-800); font-weight: 800; }
+
+.tpo-form-card #estimate-form { max-width: none; margin: 0; padding: 0; border: 0; background: transparent; box-shadow: none; }
+.tpo-form-card #estimate-form .row { gap: 16px; }
+.tpo-form-card #estimate-form input:not([type='checkbox']):not([type='radio']):not([type='file']),
+.tpo-form-card #estimate-form select,
+.tpo-form-card #estimate-form textarea { min-height: 54px; border: 1px solid #ccd7e1; border-radius: 12px; background: #fff; color: var(--ink-950); font: inherit; }
+.tpo-form-card #estimate-form textarea { min-height: 132px; }
+.tpo-form-card #estimate-form input:focus,
+.tpo-form-card #estimate-form select:focus,
+.tpo-form-card #estimate-form textarea:focus { border-color: var(--orange-500); outline: 3px solid rgba(255, 130, 0, .14); box-shadow: none; }
+.tpo-form-card #estimate-form input[type='file'] { width: 100%; min-height: 54px; padding: 8px; border: 1px solid #ccd7e1; border-radius: 12px; background: #fff; }
+.tpo-form-card #estimate-form input[type='file']::file-selector-button { min-height: 36px; margin-right: 10px; padding: 0 14px; border: 0; border-radius: 8px; background: var(--navy-900); color: #fff; font-weight: 800; }
+.tpo-form-card #estimate-form button[type='submit'] { min-height: 56px; border: 0; border-radius: 12px; background: linear-gradient(135deg, #ff9b28, var(--orange-500)); color: #071a2d; font-weight: 900; box-shadow: 0 14px 30px rgba(255, 130, 0, .22); }
+
+.tpo-final-cta { padding: 64px 0; background: linear-gradient(120deg, var(--navy-950), var(--navy-800)); color: #fff; }
+.tpo-final-cta .shell { display: flex; align-items: center; justify-content: space-between; gap: 48px; }
+.tpo-final-cta h2 { max-width: 760px; margin: 12px 0 0; color: #fff; font-size: clamp(2rem, 4vw, 3.7rem); line-height: 1.04; letter-spacing: -.045em; }
+.tpo-final-cta__actions { display: flex; flex: 0 0 auto; flex-wrap: wrap; gap: 12px; }
+
+@media (max-width: 980px) {
+  .tpo-hero__content, .tpo-split, .tpo-case-grid, .tpo-estimate-layout { grid-template-columns: 1fr; }
+  .tpo-hero__content { gap: 36px; }
+  .tpo-project-card { max-width: 520px; }
+  .tpo-split--reverse .tpo-copy { order: 0; }
+  .tpo-photo-card { max-width: 680px; }
+  .tpo-check-grid, .tpo-detail-cards { grid-template-columns: 1fr 1fr; }
+  .tpo-section-heading { grid-template-columns: 1fr; gap: 16px; }
+  .tpo-case-grid { gap: 42px; }
+  .tpo-estimate-copy { max-width: 760px; padding-top: 0; }
+  .tpo-final-cta .shell { align-items: flex-start; flex-direction: column; }
+  .tpo-process-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 720px) {
+  .tpo-page .shell { width: min(100% - 28px, 1180px); }
+  .tpo-hero { min-height: auto; }
+  .tpo-hero__content { padding-block: 74px; }
+  .tpo-hero h1 { font-size: clamp(2.75rem, 13vw, 4.1rem); }
+  .tpo-project-card { padding: 24px; }
+  .tpo-project-card strong { font-size: 3.35rem; }
+  .interior-trust__grid { grid-template-columns: 1fr 1fr; }
+  .interior-trust__grid > span, .interior-trust__grid > span:first-child { min-height: 92px; padding: 17px; border-right: 0; border-bottom: 1px solid #dfe7ef; border-left: 0; }
+  .interior-trust__grid > span:nth-child(odd) { border-right: 1px solid #dfe7ef; }
+  .tpo-section { padding: 68px 0; }
+  .tpo-copy h2, .tpo-section-heading h2, .tpo-faq-copy h2, .tpo-estimate-copy h2 { font-size: clamp(2.2rem, 10.5vw, 3.35rem); }
+  .tpo-check-grid, .tpo-methods, .tpo-detail-cards, .tpo-process-grid, .tpo-weld-steps { grid-template-columns: 1fr; }
+  .tpo-method { padding: 28px; }
+  .tpo-process-photos, .tpo-residential-grid { gap: 9px; }
+  .tpo-process-photos img, .tpo-residential-grid img { height: 190px; }
+  .tpo-process-photos figcaption, .tpo-residential-grid figcaption { display: none; }
+  .tpo-detail-list span { align-items: flex-start; flex-direction: column; gap: 5px; }
+  .tpo-detail-list small { max-width: none; text-align: left; }
+  .tpo-form-card__head, .tpo-form-card [data-include] { padding-right: 20px; padding-left: 20px; }
+  .tpo-form-note { margin-right: 20px; margin-left: 20px; }
+  .tpo-form-card #estimate-form .row { display: grid; grid-template-columns: 1fr; }
+  .tpo-final-cta__actions { width: 100%; flex-direction: column; }
+  .tpo-final-cta__actions .button { justify-content: center; width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tpo-check-grid article, .tpo-detail-cards article, .tpo-process-grid li { transition: none; }
+  .tpo-check-grid article:hover, .tpo-detail-cards article:hover, .tpo-process-grid li:hover { transform: none; }
+}

--- a/services/commercial/tpo/index.html
+++ b/services/commercial/tpo/index.html
@@ -17,7 +17,8 @@
   <meta name="twitter:card" content="summary_large_image">
   <link rel="preload" as="image" href="/images/tpo/commercial-tpo-finished.jpg">
   <link rel="stylesheet" href="/css/zenith-premium-exact.css?v=exact-premium-3">
-  <link rel="stylesheet" href="/css/tpo-premium.css?v=1">
+  <link rel="stylesheet" href="/css/estimate-form.css">
+  <link rel="stylesheet" href="/css/tpo-premium.css?v=2">
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",


### PR DESCRIPTION
## What changed

- Updated only the commercial TPO page and its scoped stylesheet.
- Matched the shared visual system used by Financing, Roof Repair, and Roof Tune-Up pages.
- Added the existing estimate-form stylesheet reference so the embedded estimate form retains the shared site styling.

## Why

The TPO page needed the same spacing, hierarchy, responsive behavior, and premium component treatment as the approved Zenith pages.

## Validation

- Confirmed the PR scope contains only two files.
- Confirmed all ten referenced TPO images exist.
- Confirmed one H1, JSON-LD, canonical URL, shared premium stylesheet, and scoped TPO stylesheet are present.
- Ran whitespace validation with no errors.