### PR TITLE
Restore separate Clay and Concrete Tile Repair paths

### DIFF
--- a/components/header-section.html
+++ b/components/header-section.html
@@ -24,7 +24,8 @@
             <a href="/services/roof-repairs/">Roof Repairs <span>→</span></a>
             <a href="/services/roof-repairs/">Roof Leak Repair <span>→</span></a>
             <a href="/services/roof-repairs/roof-tune-up/">Roof Tune-Up <span>→</span></a>
-            <a href="/services/residential/tile-roof/#repair">Clay &amp; Concrete Tile Repair <span>→</span></a>
+            <a href="/services/roof-repairs/tile-roof-repair/">Concrete Tile Roof Repair <span>→</span></a>
+            <a href="/services/roof-repairs/clay-tile-roof-repair/">Clay Tile Roof Repair <span>→</span></a>
             <a href="/services/roof-repairs/broken-tile-replacement/">Broken Tile Replacement <span>→</span></a>
             <a href="/services/roof-repairs/flat-roof-repair/">Flat Roof Repair <span>→</span></a>
             <a href="/services/roof-repairs/skylight-repair/">Skylight Repair <span>→</span></a>
@@ -93,7 +94,8 @@
         <a href="/services/roof-repairs/">Roof Repairs</a>
         <a href="/services/roof-repairs/">Roof Leak Repair</a>
         <a href="/services/roof-repairs/roof-tune-up/">Roof Tune-Up</a>
-        <a href="/services/residential/tile-roof/#repair">Clay &amp; Concrete Tile Repair</a>
+        <a href="/services/roof-repairs/tile-roof-repair/">Concrete Tile Roof Repair</a>
+        <a href="/services/roof-repairs/clay-tile-roof-repair/">Clay Tile Roof Repair</a>
         <a href="/services/roof-repairs/broken-tile-replacement/">Broken Tile Replacement</a>
         <a href="/services/roof-repairs/flat-roof-repair/">Flat Roof Repair</a>
         <a href="/services/roof-repairs/skylight-repair/">Skylight Repair</a>

--- a/services/roof-repairs/tile-roof-repair/index.html
+++ b/services/roof-repairs/tile-roof-repair/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <title>Tile Roof Leak Repair | San Diego, Escondido & Temecula</title>
-  <meta name="description" content="Tile roof leak repair that addresses damaged underlayment, chimney and skylight flashing, closed valleys, slipped tiles and drainage paths. Serving San Diego County and Temecula." />
+  <title>Concrete Tile Roof Repair | San Diego, Escondido & Temecula</title>
+  <meta name="description" content="Concrete tile roof leak repair that addresses damaged underlayment, chimney and skylight flashing, closed valleys, slipped tiles and drainage paths. Serving San Diego County and Temecula." />
   <link rel="canonical" href="https://www.zenithroofingservices.com/services/roof-repairs/tile-roof-repair/" />
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large" />
 
-  <meta property="og:title" content="Tile Roof Leak Repair | Zenith Roofing Services" />
-  <meta property="og:description" content="A broken or slipped tile may expose the problem, but the underlayment and flashing below are what keep water out. See how Zenith repairs the full drainage path." />
+  <meta property="og:title" content="Concrete Tile Roof Repair | Zenith Roofing Services" />
+  <meta property="og:description" content="A broken or slipped concrete tile may expose the problem, but the underlayment and flashing below are what keep water out. See how Zenith repairs the full drainage path." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://www.zenithroofingservices.com/services/roof-repairs/tile-roof-repair/" />
   <meta property="og:image" content="https://www.zenithroofingservices.com/images/tile-roof-repair/chimney-repair-exposed-underlayment-1200.webp" />
@@ -24,8 +24,8 @@
   {
     "@context":"https://schema.org",
     "@type":"Service",
-    "name":"Tile Roof Leak Repair",
-    "serviceType":"Concrete and clay tile roof leak repair",
+    "name":"Concrete Tile Roof Repair",
+    "serviceType":"Concrete tile roof leak repair",
     "provider":{
       "@type":"RoofingContractor",
       "name":"Zenith Roofing Services, Inc.",
@@ -62,12 +62,12 @@
   <div data-include="/components/header-section.html"></div>
 
   <main id="main-content" class="page premium-page">
-    <section class="tile-hero" aria-label="Tile roof leak repair">
+    <section class="tile-hero" aria-label="Concrete tile roof repair">
       <div class="split">
         <div>
-          <p class="eyebrow">Concrete & clay tile roof repair</p>
-          <h1>A Tile Leak Is Usually Bigger Than One Broken Tile</h1>
-          <p class="lede">Tile sheds most of the rain. The underlayment and flashing below are what protect your home when water gets through. We open the right area, trace the drainage path, and repair the waterproofing—not just the tile you can see.</p>
+          <p class="eyebrow">Concrete tile roof repair</p>
+          <h1>A Concrete Tile Leak Is Usually Bigger Than One Broken Tile</h1>
+          <p class="lede">Concrete tile sheds most of the rain. The underlayment and flashing below are what protect your home when water gets through. We open the right area, trace the drainage path, and repair the waterproofing—not just the tile you can see.</p>
           <div class="hero-actions">
             <a class="btn btn-primary" href="#estimate">Request a Tile Roof Inspection</a>
             <a class="btn btn-outline" href="#repair-or-replace">Repair or Lift &amp; Lay?</a>


### PR DESCRIPTION
## What changed

- Restores separate Services menu links for **Concrete Tile Roof Repair** and **Clay Tile Roof Repair** on desktop and mobile.
- Concrete Tile Roof Repair now explicitly identifies itself as the concrete-tile page in its title, page description, service data, and hero.
- Clay Tile Roof Repair keeps its existing specialized clay focus: one- and two-piece clay, fragile tile handling, solar damage, mortar and flashing details, and North County clay-roof experience.

## Why

Customers should be able to answer the exact question they have—concrete tile or clay tile—directly from the dropdown without being routed through a combined generic tile label.

## Validation

- Both menu destinations exist.
- Branch is based on current `main` and only changes the shared header plus the concrete tile repair page wording.
