### PR TITLE
Build premium homepage roofing authority experience

### DIFF
--- a/css/homepage-authority.css
+++ b/css/homepage-authority.css
@@ -352,6 +352,10 @@
   margin-top: 30px;
 }
 
+.authority-team__roles--single {
+  grid-template-columns: minmax(0, 520px);
+}
+
 .authority-team__role {
   padding: 23px;
   background: var(--mist);

--- a/css/homepage-authority.css
+++ b/css/homepage-authority.css
@@ -1,0 +1,631 @@
+/* Homepage authority additions
+   Scoped to the homepage sections added in the authority upgrade. */
+
+.authority-decision {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 88% 12%, rgba(42, 131, 196, 0.13), transparent 34%),
+    linear-gradient(180deg, #f7fafc 0%, #eef4f8 100%);
+}
+
+.authority-decision::before {
+  position: absolute;
+  top: -150px;
+  left: -120px;
+  width: 360px;
+  height: 360px;
+  content: "";
+  border: 1px solid rgba(6, 41, 75, 0.07);
+  border-radius: 50%;
+  box-shadow: 0 0 0 48px rgba(6, 41, 75, 0.025);
+  pointer-events: none;
+}
+
+.authority-heading {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(290px, 0.72fr);
+  align-items: end;
+  gap: clamp(34px, 7vw, 100px);
+  margin-bottom: clamp(38px, 6vw, 68px);
+}
+
+.authority-heading h2,
+.authority-written h2,
+.authority-team h2,
+.authority-faq h2 {
+  margin: 0;
+  color: var(--navy-950);
+  font-size: clamp(2.35rem, 4.5vw, 4.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+
+.authority-heading > p {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: 1.02rem;
+  line-height: 1.8;
+}
+
+.decision-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.decision-card {
+  grid-column: span 2;
+  display: flex;
+  min-width: 0;
+  min-height: 310px;
+  flex-direction: column;
+  padding: clamp(27px, 3vw, 38px);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(6, 41, 75, 0.1);
+  border-radius: 26px;
+  box-shadow: 0 18px 45px rgba(3, 26, 48, 0.08);
+  backdrop-filter: blur(14px);
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.decision-card:nth-child(4) {
+  grid-column: 2 / span 2;
+}
+
+.decision-card:nth-child(5) {
+  grid-column: 4 / span 2;
+}
+
+.decision-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 130, 0, 0.5);
+  box-shadow: 0 24px 58px rgba(3, 26, 48, 0.13);
+}
+
+.decision-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.decision-card__number {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--orange-500), var(--orange-600));
+  border-radius: 15px;
+  box-shadow: 0 12px 28px rgba(255, 130, 0, 0.24);
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+}
+
+.decision-card__top small {
+  color: var(--blue-500);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.decision-card h3 {
+  margin: 0 0 14px;
+  color: var(--navy-950);
+  font-size: clamp(1.3rem, 2vw, 1.65rem);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+}
+
+.decision-card p {
+  margin: 0 0 24px;
+  color: var(--ink-700);
+  font-size: 0.92rem;
+  line-height: 1.72;
+}
+
+.decision-card .text-link {
+  margin-top: auto;
+}
+
+.authority-card-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin-top: auto;
+}
+
+.authority-card-links .text-link {
+  min-height: 44px;
+  align-items: center;
+  font-size: 0.76rem;
+}
+
+.authority-written {
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(244, 247, 250, 0.96), #fff),
+    url("/images/Escondido/00-hero@960.jpg") center/cover;
+}
+
+.authority-written__panel {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.3fr);
+  gap: clamp(42px, 7vw, 90px);
+  overflow: hidden;
+  padding: clamp(38px, 6vw, 72px);
+  color: var(--white);
+  background:
+    radial-gradient(circle at 92% 8%, rgba(42, 131, 196, 0.32), transparent 33%),
+    linear-gradient(135deg, var(--navy-950), var(--navy-900));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 34px;
+  box-shadow: 0 32px 80px rgba(3, 26, 48, 0.22);
+}
+
+.authority-written__panel::after {
+  position: absolute;
+  right: -120px;
+  bottom: -160px;
+  width: 420px;
+  height: 420px;
+  content: "";
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 55px rgba(255, 255, 255, 0.025),
+    0 0 0 115px rgba(255, 255, 255, 0.018);
+  pointer-events: none;
+}
+
+.authority-written__copy,
+.authority-written__grid {
+  position: relative;
+  z-index: 1;
+}
+
+.authority-written h2 {
+  margin-top: 17px;
+  color: var(--white);
+  font-size: clamp(2.45rem, 4vw, 4.2rem);
+}
+
+.authority-written__copy > p {
+  margin: 24px 0 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.98rem;
+  line-height: 1.78;
+}
+
+.authority-written__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.authority-written__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 13px;
+}
+
+.authority-written__item {
+  min-width: 0;
+  padding: 21px;
+  background: rgba(255, 255, 255, 0.075);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 18px;
+  backdrop-filter: blur(12px);
+}
+
+.authority-written__item:last-child {
+  grid-column: 1 / -1;
+}
+
+.authority-written__item span {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  place-items: center;
+  margin-bottom: 15px;
+  color: var(--navy-950);
+  background: var(--orange-500);
+  border-radius: 10px;
+  font-size: 0.8rem;
+  font-weight: 900;
+}
+
+.authority-written__item h3 {
+  margin: 0 0 7px;
+  color: var(--white);
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.authority-written__item p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.78rem;
+  line-height: 1.62;
+}
+
+.authority-team {
+  background:
+    radial-gradient(circle at 92% 50%, rgba(255, 130, 0, 0.09), transparent 28%),
+    var(--white);
+}
+
+.authority-team__layout {
+  display: grid;
+  grid-template-columns: minmax(340px, 0.88fr) minmax(0, 1fr);
+  align-items: center;
+  gap: clamp(48px, 8vw, 112px);
+}
+
+.authority-team__visual {
+  position: relative;
+}
+
+.authority-team__photo {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  background: var(--mist);
+  border: 1px solid rgba(6, 41, 75, 0.1);
+  border-radius: 30px;
+  box-shadow: 0 30px 72px rgba(3, 26, 48, 0.17);
+}
+
+.authority-team__photo::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(180deg, transparent 52%, rgba(3, 26, 48, 0.68));
+  pointer-events: none;
+}
+
+.authority-team__photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.authority-team__badge {
+  position: absolute;
+  right: -22px;
+  bottom: -24px;
+  z-index: 1;
+  max-width: 260px;
+  padding: 20px 22px;
+  color: var(--white);
+  background: rgba(3, 26, 48, 0.93);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 20px;
+  box-shadow: 0 20px 50px rgba(3, 26, 48, 0.25);
+  backdrop-filter: blur(16px);
+}
+
+.authority-team__badge small {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--orange-500);
+  font-size: 0.67rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.authority-team__badge strong {
+  display: block;
+  font-size: 1.08rem;
+  line-height: 1.25;
+}
+
+.authority-team__copy h2 {
+  margin-top: 17px;
+  max-width: 760px;
+}
+
+.authority-team__lede {
+  margin: 25px 0 0;
+  color: var(--ink-700);
+  font-size: 1rem;
+  line-height: 1.82;
+}
+
+.authority-team__roles {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 30px;
+}
+
+.authority-team__role {
+  padding: 23px;
+  background: var(--mist);
+  border: 1px solid rgba(6, 41, 75, 0.09);
+  border-radius: 18px;
+}
+
+.authority-team__role small {
+  display: block;
+  color: var(--orange-600);
+  font-size: 0.66rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.authority-team__role h3 {
+  margin: 8px 0;
+  color: var(--navy-950);
+  font-size: 1.08rem;
+}
+
+.authority-team__role p {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: 0.8rem;
+  line-height: 1.62;
+}
+
+.authority-team__copy > .text-link {
+  margin-top: 28px;
+}
+
+.authority-faq {
+  position: relative;
+  overflow: hidden;
+  color: var(--white);
+  background:
+    radial-gradient(circle at 8% 8%, rgba(42, 131, 196, 0.25), transparent 30%),
+    linear-gradient(135deg, var(--navy-950), #07365f);
+}
+
+.authority-faq::after {
+  position: absolute;
+  right: -170px;
+  bottom: -220px;
+  width: 500px;
+  height: 500px;
+  content: "";
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 50%;
+  box-shadow: 0 0 0 62px rgba(255, 255, 255, 0.02);
+  pointer-events: none;
+}
+
+.authority-faq__layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(280px, 0.68fr) minmax(0, 1.2fr);
+  align-items: start;
+  gap: clamp(44px, 8vw, 110px);
+}
+
+.authority-faq h2 {
+  margin-top: 17px;
+  color: var(--white);
+}
+
+.authority-faq__intro > p {
+  margin: 24px 0 0;
+  color: rgba(255, 255, 255, 0.73);
+  font-size: 0.97rem;
+  line-height: 1.78;
+}
+
+.authority-faq__intro .button {
+  margin-top: 29px;
+}
+
+.authority-faq__list {
+  display: grid;
+  gap: 11px;
+}
+
+.authority-faq details {
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 17px;
+  backdrop-filter: blur(12px);
+  transition: background 0.25s ease, border-color 0.25s ease;
+}
+
+.authority-faq details[open] {
+  background: rgba(255, 255, 255, 0.11);
+  border-color: rgba(255, 130, 0, 0.58);
+}
+
+.authority-faq summary {
+  display: flex;
+  min-height: 68px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 22px;
+  color: var(--white);
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 800;
+  line-height: 1.35;
+  list-style: none;
+}
+
+.authority-faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.authority-faq summary span {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--navy-950);
+  background: var(--orange-500);
+  border-radius: 10px;
+  transition: transform 0.25s ease;
+}
+
+.authority-faq details[open] summary span {
+  transform: rotate(45deg);
+}
+
+.authority-faq details p {
+  margin: 0;
+  padding: 0 22px 22px;
+  color: rgba(255, 255, 255, 0.76);
+  font-size: 0.86rem;
+  line-height: 1.72;
+}
+
+.authority-faq details a {
+  color: #ffb35e;
+  font-weight: 800;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+@media (max-width: 1080px) {
+  .decision-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .decision-card,
+  .decision-card:nth-child(4),
+  .decision-card:nth-child(5) {
+    grid-column: auto;
+  }
+
+  .decision-card:last-child {
+    grid-column: 1 / -1;
+    min-height: 0;
+  }
+
+  .authority-written__panel {
+    grid-template-columns: 1fr;
+  }
+
+  .authority-team__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .authority-team__visual {
+    max-width: 780px;
+  }
+
+  .authority-team__badge {
+    right: 20px;
+  }
+}
+
+@media (max-width: 820px) {
+  .authority-heading,
+  .authority-faq__layout {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .authority-heading {
+    align-items: start;
+  }
+
+  .authority-heading > p,
+  .authority-faq__intro > p {
+    max-width: 680px;
+  }
+
+  .authority-written__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .authority-written__item:last-child {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 620px) {
+  .authority-heading h2,
+  .authority-written h2,
+  .authority-team h2,
+  .authority-faq h2 {
+    font-size: clamp(2.18rem, 10.5vw, 3.1rem);
+    line-height: 1.02;
+  }
+
+  .decision-grid,
+  .authority-team__roles {
+    grid-template-columns: 1fr;
+  }
+
+  .decision-card,
+  .decision-card:last-child {
+    grid-column: auto;
+    min-height: 0;
+    padding: 27px 23px;
+  }
+
+  .authority-written__panel {
+    padding: 34px 21px;
+    border-radius: 25px;
+  }
+
+  .authority-written__actions {
+    display: grid;
+  }
+
+  .authority-written__actions .button {
+    width: 100%;
+  }
+
+  .authority-team__photo {
+    aspect-ratio: 4 / 3;
+    border-radius: 23px;
+  }
+
+  .authority-team__badge {
+    position: relative;
+    right: auto;
+    bottom: auto;
+    max-width: none;
+    margin: -28px 16px 0;
+  }
+
+  .authority-faq summary {
+    min-height: 72px;
+    padding: 17px 18px;
+    font-size: 0.88rem;
+  }
+
+  .authority-faq details p {
+    padding: 0 18px 20px;
+    font-size: 0.82rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .decision-card,
+  .authority-faq summary span {
+    transition: none;
+  }
+
+  .decision-card:hover {
+    transform: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -450,12 +450,11 @@
           <div class="authority-team__badge"><small>Local since 2017</small><strong>CSLB C-39 #1036112</strong></div>
         </div>
         <div class="authority-team__copy">
-          <span class="eyebrow">The people behind Zenith</span>
-          <h2 id="team-heading">Local leadership from inspection through final review.</h2>
-          <p class="authority-team__lede">Bryan Ramirez founded Zenith Roofing Services in 2017 to provide property owners with clear recommendations, documented scopes and accountable roofing work. Zenith remains locally operated, with field decisions and quality oversight connected directly to the people responsible for the project.</p>
-          <div class="authority-team__roles">
+          <span class="eyebrow">Owner-led accountability</span>
+          <h2 id="team-heading">Direct oversight from inspection through final review.</h2>
+          <p class="authority-team__lede">Bryan Ramirez founded Zenith Roofing Services in 2017 to provide property owners with clear recommendations, documented scopes and accountable roofing work. Zenith remains locally operated, and Bryan stays connected to recommendations, written scopes, system selections and final quality oversight.</p>
+          <div class="authority-team__roles authority-team__roles--single">
             <article class="authority-team__role"><small>Owner &amp; founder</small><h3>Bryan Ramirez</h3><p>Oversees recommendations, system selections, written scopes and final quality review.</p></article>
-            <article class="authority-team__role"><small>Field operations</small><h3>Omar</h3><p>Coordinates crew execution, jobsite progress and daily field-quality details.</p></article>
           </div>
           <a class="text-link" href="/about/">Meet Zenith Roofing Services <span>→</span></a>
         </div>

--- a/index.html
+++ b/index.html
@@ -5,11 +5,208 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <title>Zenith Roofing Services | Escondido, San Diego &amp; Temecula Roofer</title>
   <meta name="description" content="Licensed Southern California roofing contractor for roof repair, replacement, tile, shingles, TPO, torch-down, silicone coatings and gutters.">
+  <meta property="og:title" content="Zenith Roofing Services | Southern California Roofing Contractor">
+  <meta property="og:description" content="Clear roofing recommendations, documented workmanship and verified manufacturer programs for properties across San Diego County and the Temecula Valley.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://www.zenithroofingservices.com/">
+  <meta property="og:image" content="https://www.zenithroofingservices.com/images/modern-tile-roof-1600.webp">
+  <meta name="twitter:card" content="summary_large_image">
   <link rel="canonical" href="https://www.zenithroofingservices.com/">
   <link rel="icon" href="/zenith-favicon-v3.png">
   <link rel="preload" as="image" href="/images/modern-tile-roof-1600.webp">
   <link rel="stylesheet" href="/css/zenith-premium-exact.css?v=exact-premium-3">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"RoofingContractor","name":"Zenith Roofing Services, Inc.","telephone":"+1-858-900-6163","url":"https://www.zenithroofingservices.com/","areaServed":["Escondido","San Diego","Temecula","North County San Diego"],"identifier":"CSLB C-39 #1036112"}</script>
+  <link rel="stylesheet" href="/css/homepage-authority.css?v=1">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": [
+          "RoofingContractor",
+          "LocalBusiness"
+        ],
+        "@id": "https://www.zenithroofingservices.com/#business",
+        "name": "Zenith Roofing Services, Inc.",
+        "legalName": "Zenith Roofing Services, Inc.",
+        "url": "https://www.zenithroofingservices.com/",
+        "logo": "https://www.zenithroofingservices.com/images/zenith-roofing-shirt-logo-original.png",
+        "image": "https://www.zenithroofingservices.com/images/modern-tile-roof-1600.webp",
+        "telephone": "+1-858-900-6163",
+        "foundingDate": "2017",
+        "founder": {
+          "@type": "Person",
+          "name": "Bryan Ramirez"
+        },
+        "identifier": {
+          "@type": "PropertyValue",
+          "propertyID": "California CSLB C-39",
+          "value": "1036112"
+        },
+        "areaServed": [
+          {
+            "@type": "AdministrativeArea",
+            "name": "San Diego County, California"
+          },
+          {
+            "@type": "City",
+            "name": "Escondido, California"
+          },
+          {
+            "@type": "City",
+            "name": "San Diego, California"
+          },
+          {
+            "@type": "City",
+            "name": "Temecula, California"
+          },
+          {
+            "@type": "City",
+            "name": "Murrieta, California"
+          }
+        ],
+        "sameAs": [
+          "https://share.google/tu1mPk3Oim7OPFiqS",
+          "https://share.google/2Ok3Yz6IHsJMdQvh3",
+          "https://www.yelp.com/biz/zenith-roofing-services-escondido",
+          "https://www.thumbtack.com/ca/escondido/roofing/zenith-roofing-services-inc/service/295721236717715636"
+        ],
+        "hasOfferCatalog": {
+          "@type": "OfferCatalog",
+          "name": "Roofing services",
+          "itemListElement": [
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Roof repair and leak diagnosis",
+                "url": "https://www.zenithroofingservices.com/services/roof-repairs/"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Tile roof lift and relay",
+                "url": "https://www.zenithroofingservices.com/services/residential/tile-lift-lay/"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Asphalt shingle roof replacement",
+                "url": "https://www.zenithroofingservices.com/services/residential/asphalt-shingles/"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Commercial and flat roofing",
+                "url": "https://www.zenithroofingservices.com/services/commercial/"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Roof inspections and real-estate roofing services",
+                "url": "https://www.zenithroofingservices.com/services/roof-inspection/"
+              }
+            },
+            {
+              "@type": "Offer",
+              "itemOffered": {
+                "@type": "Service",
+                "name": "Gutters, skylights and roof accessories",
+                "url": "https://www.zenithroofingservices.com/services/gutters/"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://www.zenithroofingservices.com/#website",
+        "url": "https://www.zenithroofingservices.com/",
+        "name": "Zenith Roofing Services",
+        "publisher": {
+          "@id": "https://www.zenithroofingservices.com/#business"
+        }
+      },
+      {
+        "@type": "FAQPage",
+        "@id": "https://www.zenithroofingservices.com/#roofing-faq",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Can my roof be repaired instead of replaced?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Often, yes. A repair can be appropriate when the damage is isolated and the surrounding roof assembly remains serviceable. Zenith inspects the source and overall roof condition before recommending the smallest responsible scope."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "When does a tile roof need a lift and relay?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A lift and relay can make sense when existing clay or concrete tile is reusable but the underlayment, flashings or related waterproofing details have reached the end of their useful life."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which flat-roof systems work in Southern California?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Depending on the property and existing assembly, options may include TPO, torch-down or self-adhered modified bitumen, and silicone restoration when the existing roof is dry, stable and eligible."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Are roofing estimates free?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Estimates for planned roofing work are generally free. Real-estate transaction services, including written inspections, reports, certifications and certain estimate requests, are paid professional services."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Zenith offer financing?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Financing options are available through third-party financing for qualified customers. Approval, rates and terms are provided by the financing company."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Zenith provide photo documentation?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Zenith uses photos to document inspection findings and important stages of the work. Documentation requirements should be discussed before work so the required deliverable can be included in the written scope."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What happens if damaged wood is found?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The proposal explains how concealed or damaged wood is handled. When additional work is needed, Zenith documents the condition and follows the written pricing and change-order process."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which areas does Zenith serve?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Zenith serves properties across San Diego County and the Temecula Valley, including Escondido, San Marcos, Vista, Oceanside, Poway, Rancho Santa Fe, Murrieta and Temecula."
+            }
+          }
+        ]
+      }
+    ]
+  }
+  </script>
 </head>
 <body>
   <section data-include="/components/header-section.html"></section>
@@ -79,13 +276,79 @@
       </div>
     </section>
 
+    <section class="section authority-decision" aria-labelledby="decision-heading">
+      <div class="shell">
+        <div class="authority-heading">
+          <div>
+            <span class="eyebrow">A clear roofing decision</span>
+            <h2 id="decision-heading">Repair, lift and relay, or replace?</h2>
+          </div>
+          <p>We start with the roof’s actual condition—not a predetermined sale. The right path depends on where the system is failing, how much serviceable life remains and whether the existing materials can be responsibly reused.</p>
+        </div>
+
+        <div class="decision-grid">
+          <article class="decision-card">
+            <div class="decision-card__top"><span class="decision-card__number">01</span><small>Isolated damage</small></div>
+            <h3>Localized roof repair</h3>
+            <p>Best when the leak or damage is limited and the surrounding roof assembly remains serviceable. We trace the source and repair the failed detail instead of covering the visible symptom.</p>
+            <a class="text-link" href="/services/roof-repairs/">Explore roof repairs <span>→</span></a>
+          </article>
+          <article class="decision-card">
+            <div class="decision-card__top"><span class="decision-card__number">02</span><small>Maintenance path</small></div>
+            <h3>Roof tune-up</h3>
+            <p>Useful when a generally serviceable roof needs attention at penetrations, flashings, exposed fasteners, loose tiles, sealants or debris-prone drainage areas.</p>
+            <a class="text-link" href="/services/roof-repairs/roof-tune-up/">See the tune-up process <span>→</span></a>
+          </article>
+          <article class="decision-card">
+            <div class="decision-card__top"><span class="decision-card__number">03</span><small>Reuse serviceable tile</small></div>
+            <h3>Tile lift and relay</h3>
+            <p>Often appropriate when existing clay or concrete tile can be reused but the underlayment and flashing details beneath it need renewal.</p>
+            <a class="text-link" href="/services/residential/tile-lift-lay/">Explore tile lift and relay <span>→</span></a>
+          </article>
+          <article class="decision-card">
+            <div class="decision-card__top"><span class="decision-card__number">04</span><small>System-wide solution</small></div>
+            <h3>Complete roof replacement</h3>
+            <p>Recommended when failures are widespread, the system is no longer dependable, the deck requires major correction or a complete material change is the responsible long-term choice.</p>
+            <a class="text-link" href="/services/roof-replacement/">Compare replacement paths <span>→</span></a>
+          </article>
+          <article class="decision-card">
+            <div class="decision-card__top"><span class="decision-card__number">05</span><small>Low-slope evaluation</small></div>
+            <h3>Flat-roof restoration or replacement</h3>
+            <p>Moisture, adhesion, deck condition, drainage and membrane condition determine whether a coating restoration, targeted repair or new TPO or modified-bitumen system is appropriate.</p>
+            <a class="text-link" href="/services/roof-replacement/flat-roof/">Explore flat-roof options <span>→</span></a>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <section class="section section--services" id="services">
       <div class="shell">
-        <div class="section-heading"><div><span class="eyebrow">Roofing services</span><h2>The right solution—not the biggest sale.</h2></div><p>We inspect first, explain what we find and help you choose the right path for your property, budget and timeline.</p></div>
+        <div class="section-heading"><div><span class="eyebrow">Six clear roofing paths</span><h2>Start with the service that fits your property.</h2></div><p>Each path connects to a dedicated Zenith authority page with the systems, process and field details that matter for that type of work.</p></div>
         <div class="service-grid">
-          <article class="service-card"><a class="service-card__image" href="/services/roof-repairs/"><img src="/images/tile-roof-repair/tile-roof-chimney-completed-1200.webp" alt="Completed tile roof chimney repair" width="720" height="520" loading="lazy"><span>Repairs</span></a><div class="service-card__body"><span class="service-card__number">01</span><h3>Roof Repair</h3><p>Pinpoint leaks, failed flashing, broken tiles and storm damage—then repair the source, not just the symptom.</p><a class="text-link" href="/services/roof-repairs/">Explore service <span>→</span></a></div></article>
-          <article class="service-card"><a class="service-card__image" href="/services/roof-replacement/"><img src="/images/modern-tile-roof-1280.webp" alt="Completed residential tile roof" width="720" height="520" loading="lazy"><span>Re-roofing</span></a><div class="service-card__body"><span class="service-card__number">02</span><h3>Roof Replacement</h3><p>A complete roofing system built for your property, climate and long-term performance—with every layer documented.</p><a class="text-link" href="/services/roof-replacement/">Explore service <span>→</span></a></div></article>
-          <article class="service-card"><a class="service-card__image" href="/services/commercial/"><img src="/images/roof-tune-up/commercial-roof-tune-up-overview-1200.webp" alt="Commercial flat roof inspection" width="720" height="520" loading="lazy"><span>Commercial</span></a><div class="service-card__body"><span class="service-card__number">03</span><h3>Commercial &amp; Flat Roofing</h3><p>TPO, torch-down and silicone restoration options for businesses, HOAs and property managers.</p><a class="text-link" href="/services/commercial/">Explore service <span>→</span></a></div></article>
+          <article class="service-card">
+            <a class="service-card__image" href="/services/roof-repairs/"><img src="/images/tile-roof-repair/tile-roof-chimney-completed-1200.webp" alt="Completed tile roof and chimney repair by Zenith Roofing Services" width="720" height="520" loading="lazy"><span>Diagnosis &amp; repair</span></a>
+            <div class="service-card__body"><span class="service-card__number">01</span><h3>Roof Repair &amp; Leak Diagnosis</h3><p>Find the source of leaks, failed flashing, broken materials and localized damage before choosing the smallest responsible repair.</p><div class="authority-card-links"><a class="text-link" href="/services/roof-repairs/">Roof repairs <span>→</span></a><a class="text-link" href="/services/roof-repairs/roof-tune-up/">Tune-ups <span>→</span></a></div></div>
+          </article>
+          <article class="service-card">
+            <a class="service-card__image" href="/services/residential/tile-lift-lay/"><img src="/images/modern-tile-roof-1280.webp" alt="Completed Southern California tile roof installed by Zenith Roofing Services" width="720" height="520" loading="lazy"><span>Clay &amp; concrete tile</span></a>
+            <div class="service-card__body"><span class="service-card__number">02</span><h3>Tile Roofing &amp; Lift-and-Relay</h3><p>Repair tile roofs, renew the waterproofing beneath reusable tile or install a complete new clay or concrete tile system.</p><div class="authority-card-links"><a class="text-link" href="/services/residential/tile-lift-lay/">Lift and relay <span>→</span></a><a class="text-link" href="/services/residential/tile-roof/">Tile replacement <span>→</span></a></div></div>
+          </article>
+          <article class="service-card">
+            <a class="service-card__image" href="/services/residential/asphalt-shingles/"><img src="/images/owens-corning/completed-owens-corning-shingle-roof.webp" alt="Completed Owens Corning Duration COOL shingle roof in Sand Castle" width="720" height="520" loading="lazy"><span>Asphalt shingles</span></a>
+            <div class="service-card__body"><span class="service-card__number">03</span><h3>Asphalt-Shingle Replacement</h3><p>Complete shingle systems with documented deck preparation, flashing, ventilation and qualifying manufacturer warranty options.</p><div class="authority-card-links"><a class="text-link" href="/services/residential/asphalt-shingles/">Explore shingle systems <span>→</span></a></div></div>
+          </article>
+          <article class="service-card">
+            <a class="service-card__image" href="/services/commercial/"><img src="/images/torch-down-point-loma-720.webp" alt="Completed low-slope roofing system in Point Loma" width="720" height="520" loading="lazy"><span>Low-slope systems</span></a>
+            <div class="service-card__body"><span class="service-card__number">04</span><h3>TPO, Torch-Down &amp; Flat Roofing</h3><p>Repair, restoration and replacement paths for homes, commercial buildings, HOAs and managed properties.</p><div class="authority-card-links"><a class="text-link" href="/services/commercial/tpo/">TPO <span>→</span></a><a class="text-link" href="/services/commercial/torch-down/">Torch-down <span>→</span></a><a class="text-link" href="/services/roof-repairs/flat-roof-repair/">Flat-roof repair <span>→</span></a></div></div>
+          </article>
+          <article class="service-card">
+            <a class="service-card__image" href="/services/roof-inspection/"><img src="/images/asphalt-shingles/shingle-tearoff-deck-inspection.webp" alt="Roof deck being inspected during a Zenith Roofing Services project" width="720" height="520" loading="lazy"><span>Professional findings</span></a>
+            <div class="service-card__body"><span class="service-card__number">05</span><h3>Roof Inspections &amp; Real Estate</h3><p>Photo-documented evaluations, roof reports, certifications and transaction-specific services with clear deliverables and fees.</p><div class="authority-card-links"><a class="text-link" href="/services/roof-inspection/">Roof inspections <span>→</span></a><a class="text-link" href="/services/real-estate/">Real-estate services <span>→</span></a></div></div>
+          </article>
+          <article class="service-card">
+            <a class="service-card__image" href="/services/gutters/"><img src="/images/skylight-repair/completed-skylight-repair-1200.webp" alt="Completed tile roof skylight flashing repair by Zenith Roofing Services" width="720" height="520" loading="lazy"><span>Roof accessories</span></a>
+            <div class="service-card__body"><span class="service-card__number">06</span><h3>Gutters, Skylights &amp; Accessories</h3><p>Details that protect drainage and roof penetrations, including seamless gutters, skylight repairs and related roof accessories.</p><div class="authority-card-links"><a class="text-link" href="/services/gutters/">Seamless gutters <span>→</span></a><a class="text-link" href="/services/roof-repairs/skylight-repair/">Skylight repair <span>→</span></a></div></div>
+          </article>
         </div>
         <div class="section-action"><a class="button button--navy" href="/services/">Explore Every Roofing Service <span>→</span></a></div>
       </div>
@@ -141,6 +404,31 @@
       </div>
     </section>
 
+    <section class="section authority-written" aria-labelledby="written-heading">
+      <div class="shell">
+        <div class="authority-written__panel">
+          <div class="authority-written__copy">
+            <span class="eyebrow eyebrow--light">What you receive in writing</span>
+            <h2 id="written-heading">Clear expectations before roofing work begins.</h2>
+            <p>Your proposal should explain more than a price. Zenith documents the selected scope, roofing system, responsibilities and procedures that affect the work so you can understand what is included and how unexpected conditions are handled.</p>
+            <div class="authority-written__actions">
+              <a class="button button--orange" href="#estimate">Request an estimate <span>→</span></a>
+              <a class="button button--ghost-light" href="/about/">How Zenith works</a>
+            </div>
+          </div>
+          <div class="authority-written__grid">
+            <article class="authority-written__item"><span>✓</span><h3>A defined roofing scope</h3><p>The roof areas, work being performed and included responsibilities are identified.</p></article>
+            <article class="authority-written__item"><span>✓</span><h3>Named system components</h3><p>Primary materials, layers and important roof-system components are described.</p></article>
+            <article class="authority-written__item"><span>✓</span><h3>Photo documentation</h3><p>Inspection findings and important project stages are documented for clarity.</p></article>
+            <article class="authority-written__item"><span>✓</span><h3>Wood and change procedures</h3><p>Concealed damage, additional work and written change-order procedures are addressed.</p></article>
+            <article class="authority-written__item"><span>✓</span><h3>Protection and cleanup</h3><p>Reasonable property-protection and jobsite-cleanup expectations are stated.</p></article>
+            <article class="authority-written__item"><span>✓</span><h3>Warranty information</h3><p>Zenith workmanship coverage and eligible manufacturer options are explained separately.</p></article>
+            <article class="authority-written__item"><span>✓</span><h3>Payment and scheduling terms</h3><p>The proposal states applicable payment stages, scheduling expectations and project conditions.</p></article>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="section section--projects">
       <div class="shell">
         <div class="section-heading section-heading--light"><div><span class="eyebrow eyebrow--light">Real work. Real local roofs.</span><h2>Recent Zenith projects.</h2></div><p>No stock project gallery. These are documented roofing systems completed across Southern California.</p></div>
@@ -150,6 +438,27 @@
           <a class="project-card" href="/projects/"><img src="/images/torch-down-point-loma-720.webp" alt="Completed torch-down flat roof" width="960" height="720" loading="lazy"><span class="project-card__shade"></span><span class="project-card__content"><small>📍 Point Loma, CA</small><strong>Torch-down flat roofing system</strong><i>View project →</i></span></a>
         </div>
         <div class="section-action section-action--light"><a class="button button--ghost-light" href="/projects/">View Our Project Gallery <span>→</span></a></div>
+      </div>
+    </section>
+
+    <section class="section authority-team" aria-labelledby="team-heading">
+      <div class="shell authority-team__layout">
+        <div class="authority-team__visual">
+          <div class="authority-team__photo">
+            <img src="/images/tile-roof-replacement/crew-new-tile.jpg" alt="Zenith Roofing Services crew installing a new tile roofing system" width="960" height="720" loading="lazy">
+          </div>
+          <div class="authority-team__badge"><small>Local since 2017</small><strong>CSLB C-39 #1036112</strong></div>
+        </div>
+        <div class="authority-team__copy">
+          <span class="eyebrow">The people behind Zenith</span>
+          <h2 id="team-heading">Local leadership from inspection through final review.</h2>
+          <p class="authority-team__lede">Bryan Ramirez founded Zenith Roofing Services in 2017 to provide property owners with clear recommendations, documented scopes and accountable roofing work. Zenith remains locally operated, with field decisions and quality oversight connected directly to the people responsible for the project.</p>
+          <div class="authority-team__roles">
+            <article class="authority-team__role"><small>Owner &amp; founder</small><h3>Bryan Ramirez</h3><p>Oversees recommendations, system selections, written scopes and final quality review.</p></article>
+            <article class="authority-team__role"><small>Field operations</small><h3>Omar</h3><p>Coordinates crew execution, jobsite progress and daily field-quality details.</p></article>
+          </div>
+          <a class="text-link" href="/about/">Meet Zenith Roofing Services <span>→</span></a>
+        </div>
       </div>
     </section>
 
@@ -163,6 +472,51 @@
         </div>
         <div class="platform-row"><span>Google</span><span>HomeAdvisor</span><span>Yelp</span><span>GuildQuality</span><span>Owens Corning</span><span>Angi</span><span>Thumbtack</span></div>
         <div class="section-action"><a class="button button--navy" href="/reviews/">Read Customer Reviews <span>→</span></a></div>
+      </div>
+    </section>
+
+    <section class="section authority-faq" aria-labelledby="faq-heading">
+      <div class="shell authority-faq__layout">
+        <div class="authority-faq__intro">
+          <span class="eyebrow eyebrow--light">Roofing questions, answered</span>
+          <h2 id="faq-heading">Straight answers before you make a roofing decision.</h2>
+          <p>These are the practical questions property owners, managers and real-estate professionals ask before choosing a repair, replacement or inspection service.</p>
+          <a class="button button--orange" href="/contact/">Ask Zenith about your roof</a>
+        </div>
+        <div class="authority-faq__list">
+          <details>
+            <summary>Can my roof be repaired instead of replaced?<span aria-hidden="true">+</span></summary>
+            <p>Often, yes. A repair can be appropriate when the damage is isolated and the surrounding roof assembly remains serviceable. Zenith inspects the source, nearby flashing, underlayment or membrane, and the overall roof condition before recommending the smallest responsible scope.</p>
+          </details>
+          <details>
+            <summary>When does a tile roof need a lift and relay?<span aria-hidden="true">+</span></summary>
+            <p>A lift and relay can make sense when the existing clay or concrete tile is reusable but the underlayment, flashings or related waterproofing details have reached the end of their useful life. The tiles are removed, the waterproofing assembly is renewed, and serviceable tiles are reinstalled.</p>
+          </details>
+          <details>
+            <summary>Which flat-roof systems work in Southern California?<span aria-hidden="true">+</span></summary>
+            <p>Depending on the property and existing assembly, options may include TPO, torch-down or self-adhered modified bitumen, and silicone restoration when the existing roof is dry, stable and eligible. Drainage, deck condition, moisture and flashing details determine the right approach.</p>
+          </details>
+          <details>
+            <summary>Are roofing estimates free?<span aria-hidden="true">+</span></summary>
+            <p>Estimates for planned roofing work are generally free. Real-estate transaction services—including written inspections, reports, certifications and certain estimate requests—are paid professional services. <a href="/pricing/#real-estate">Review real-estate pricing</a>.</p>
+          </details>
+          <details>
+            <summary>Does Zenith offer financing?<span aria-hidden="true">+</span></summary>
+            <p>Yes. Financing options are available through third-party financing for qualified customers. Approval, rates and terms are provided by the financing company. <a href="/financing/">Explore financing options</a>.</p>
+          </details>
+          <details>
+            <summary>Does Zenith provide photo documentation?<span aria-hidden="true">+</span></summary>
+            <p>Yes. Zenith uses photos to document inspection findings and important stages of the work. If you need records for an insurer, HOA, real-estate transaction or property file, tell us before work so the required deliverable can be included in the written scope.</p>
+          </details>
+          <details>
+            <summary>What happens if damaged wood is found?<span aria-hidden="true">+</span></summary>
+            <p>The proposal explains how concealed or damaged wood is handled. When additional work is needed, Zenith documents the condition and follows the written pricing and change-order process before proceeding, except where immediate temporary protection is required.</p>
+          </details>
+          <details>
+            <summary>Which areas does Zenith serve?<span aria-hidden="true">+</span></summary>
+            <p>Zenith serves properties across San Diego County and the Temecula Valley, including Escondido, San Marcos, Vista, Oceanside, Poway, Rancho Santa Fe, Murrieta and Temecula. <a href="/service-areas/">View all service areas</a>.</p>
+          </details>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- adds a five-path repair, tune-up, lift-and-relay, replacement and flat-roof decision guide
- expands the homepage from three general service cards to six clear roofing service paths with verified authority-page links
- adds a premium “What you receive in writing” section based on Zenith’s real proposal and project-protection practices
- adds owner-led local-company proof with Bryan Ramirez, Zenith’s 2017 founding and CSLB C-39 #1036112
- adds eight visible homeowner, property-manager and real-estate FAQs
- expands homepage JSON-LD into RoofingContractor/LocalBusiness, WebSite and FAQPage entities
- adds Open Graph metadata while preserving the current canonical for the separate technical SEO PR

## Design and content
- uses the approved Zenith navy, orange, mist, glass, card, shadow and responsive design language
- reuses verified real Zenith project photography already in the repository
- keeps the existing premium hero, estimate form, manufacturer credentials, reviews, projects and service-area sections
- keeps all three homepage project cards pointed to `/projects/`, including Escondido, per the latest direction
- adds one scoped stylesheet: `css/homepage-authority.css`

## Functional protection
- preserves the JobNimbus/Netlify form action and every existing field name
- preserves reCAPTCHA, shared loader/menu behavior, footer, phone links and tracking scripts
- does not publish any GAF status or other unearned credential
- does not change sitewide canonical, robots.txt, sitemap or server-rendered navigation; those remain a separate technical SEO PR

## Verification
- started from current merged `main` at `e9cd327`
- verified all seven real project images used by the homepage exist on the branch
- verified every new service, financing, pricing, contact, about, service-area and projects destination exists
- confirmed one H1, no duplicate IDs, six service cards, five decision cards, seven written-scope items and eight FAQs
- parsed the expanded JSON-LD successfully
- confirmed balanced CSS braces and responsive breakpoints at 1080px, 820px and 620px
- compared against `main`: only `index.html` and the new scoped homepage stylesheet