### PR TITLE
Polish homepage estimate form with premium hierarchy

### DIFF
--- a/css/homepage-authority.css
+++ b/css/homepage-authority.css
@@ -557,38 +557,27 @@
   max-height: 64px;
 }
 
-/* Keep the homepage estimate-fee distinction easy to read without changing form behavior. */
-.estimate-form__fee-notice {
-  grid-template-columns: 38px minmax(0, 1fr);
-  gap: 13px;
-  margin: 2px 0 20px;
-  padding: 15px 16px;
-  border-radius: 15px;
-  box-shadow:
-    inset 4px 0 0 var(--orange-500),
-    0 10px 24px rgba(3, 26, 48, 0.06);
+/* Make the form purpose the dominant heading without changing form behavior. */
+.estimate-form__heading .eyebrow {
+  margin-bottom: 11px;
+  font-size: clamp(1.55rem, 1.7vw, 1.72rem);
+  font-weight: 900;
+  letter-spacing: 0.025em;
+  line-height: 1.08;
 }
 
-.estimate-form__fee-icon {
-  width: 38px;
-  height: 38px;
-  font-size: 0.86rem;
+.estimate-form__heading .eyebrow::before {
+  width: 34px;
+  height: 3px;
 }
 
-.estimate-form__fee-notice p {
-  font-size: 0.84rem;
-  line-height: 1.52;
+.estimate-form__heading h2 {
+  font-size: 1.35rem;
+  letter-spacing: -0.025em;
 }
 
-.estimate-form__fee-notice strong {
-  margin-bottom: 3px;
-  font-size: 0.96rem;
-  line-height: 1.35;
-}
-
-.estimate-form__fee-notice a {
-  margin-top: 2px;
-  font-size: 0.84rem;
+.estimate-form__heading p {
+  font-size: 0.82rem;
 }
 
 @media (max-width: 1080px) {
@@ -650,26 +639,18 @@
 }
 
 @media (max-width: 620px) {
-  .estimate-form__fee-notice {
-    grid-template-columns: 34px minmax(0, 1fr);
-    gap: 11px;
-    margin-bottom: 17px;
-    padding: 13px 14px;
+  .estimate-form__heading .eyebrow {
+    gap: 8px;
+    font-size: 1.25rem;
+    letter-spacing: 0.02em;
   }
 
-  .estimate-form__fee-icon {
-    width: 34px;
-    height: 34px;
-    font-size: 0.78rem;
+  .estimate-form__heading .eyebrow::before {
+    width: 23px;
   }
 
-  .estimate-form__fee-notice p,
-  .estimate-form__fee-notice a {
-    font-size: 0.8rem;
-  }
-
-  .estimate-form__fee-notice strong {
-    font-size: 0.9rem;
+  .estimate-form__heading h2 {
+    font-size: 1.18rem;
   }
 
   .manufacturer-card__brand {

--- a/css/homepage-authority.css
+++ b/css/homepage-authority.css
@@ -557,27 +557,49 @@
   max-height: 64px;
 }
 
-/* Make the form purpose the dominant heading without changing form behavior. */
+/* Give the form a calm premium hierarchy without changing form behavior. */
 .estimate-form__heading .eyebrow {
-  margin-bottom: 11px;
-  font-size: clamp(1.55rem, 1.7vw, 1.72rem);
+  gap: 7px;
+  margin-bottom: 13px;
+  padding: 7px 11px;
+  color: var(--orange-600);
+  background: linear-gradient(135deg, rgba(255, 130, 0, 0.11), rgba(255, 255, 255, 0.58));
+  border: 1px solid rgba(255, 130, 0, 0.22);
+  border-radius: 999px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.78),
+    0 8px 20px rgba(237, 106, 0, 0.08);
+  font-size: 0.64rem;
   font-weight: 900;
-  letter-spacing: 0.025em;
-  line-height: 1.08;
+  letter-spacing: 0.15em;
+  line-height: 1;
 }
 
 .estimate-form__heading .eyebrow::before {
-  width: 34px;
-  height: 3px;
+  width: 15px;
+  height: 2px;
 }
 
 .estimate-form__heading h2 {
-  font-size: 1.35rem;
-  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--navy-950);
+  font-size: clamp(1.9rem, 2.25vw, 2.2rem);
+  font-weight: 850;
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+  text-wrap: balance;
 }
 
 .estimate-form__heading p {
-  font-size: 0.82rem;
+  margin-top: 11px;
+  color: var(--ink-500);
+  font-size: 0.84rem;
+  line-height: 1.52;
+}
+
+.estimate-form__heading p strong {
+  color: var(--navy-900);
+  font-weight: 800;
 }
 
 @media (max-width: 1080px) {
@@ -640,17 +662,23 @@
 
 @media (max-width: 620px) {
   .estimate-form__heading .eyebrow {
-    gap: 8px;
-    font-size: 1.25rem;
-    letter-spacing: 0.02em;
+    gap: 6px;
+    margin-bottom: 11px;
+    padding: 6px 10px;
+    font-size: 0.61rem;
+    letter-spacing: 0.14em;
   }
 
   .estimate-form__heading .eyebrow::before {
-    width: 23px;
+    width: 12px;
   }
 
   .estimate-form__heading h2 {
-    font-size: 1.18rem;
+    font-size: clamp(1.72rem, 8vw, 2rem);
+  }
+
+  .estimate-form__heading p {
+    font-size: 0.79rem;
   }
 
   .manufacturer-card__brand {

--- a/css/homepage-authority.css
+++ b/css/homepage-authority.css
@@ -557,6 +557,40 @@
   max-height: 64px;
 }
 
+/* Keep the homepage estimate-fee distinction easy to read without changing form behavior. */
+.estimate-form__fee-notice {
+  grid-template-columns: 38px minmax(0, 1fr);
+  gap: 13px;
+  margin: 2px 0 20px;
+  padding: 15px 16px;
+  border-radius: 15px;
+  box-shadow:
+    inset 4px 0 0 var(--orange-500),
+    0 10px 24px rgba(3, 26, 48, 0.06);
+}
+
+.estimate-form__fee-icon {
+  width: 38px;
+  height: 38px;
+  font-size: 0.86rem;
+}
+
+.estimate-form__fee-notice p {
+  font-size: 0.84rem;
+  line-height: 1.52;
+}
+
+.estimate-form__fee-notice strong {
+  margin-bottom: 3px;
+  font-size: 0.96rem;
+  line-height: 1.35;
+}
+
+.estimate-form__fee-notice a {
+  margin-top: 2px;
+  font-size: 0.84rem;
+}
+
 @media (max-width: 1080px) {
   .decision-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -616,6 +650,28 @@
 }
 
 @media (max-width: 620px) {
+  .estimate-form__fee-notice {
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 11px;
+    margin-bottom: 17px;
+    padding: 13px 14px;
+  }
+
+  .estimate-form__fee-icon {
+    width: 34px;
+    height: 34px;
+    font-size: 0.78rem;
+  }
+
+  .estimate-form__fee-notice p,
+  .estimate-form__fee-notice a {
+    font-size: 0.8rem;
+  }
+
+  .estimate-form__fee-notice strong {
+    font-size: 0.9rem;
+  }
+
   .manufacturer-card__brand {
     min-height: 78px;
     margin-bottom: 22px;

--- a/index.html
+++ b/index.html
@@ -238,9 +238,9 @@
           <form id="estimate-form" class="estimate-form estimate-form--compact" action="/.netlify/functions/jn-create-lead" method="POST">
             <input id="state" type="hidden" name="state" value="CA">
             <div class="estimate-form__heading">
-              <span class="eyebrow">Free roofing estimate</span>
-              <h2>Tell us about your roof</h2>
-              <p>Fast response. Clear next steps. No pressure.</p>
+              <span class="eyebrow">Start here</span>
+              <h2>Free roofing estimate</h2>
+              <p><strong>Tell us about your roof.</strong> Fast response. Clear next steps. No pressure.</p>
             </div>
             <aside class="estimate-form__fee-notice" aria-label="Real-estate transaction service fee notice">
               <span class="estimate-form__fee-icon" aria-hidden="true">i</span>


### PR DESCRIPTION
## Summary
- replaces the loud two-line all-caps treatment with a refined navy “Free roofing estimate” display title
- adds a restrained frosted-orange “Start here” label for premium hierarchy
- moves “Tell us about your roof” into the supporting copy while preserving the fast-response message
- keeps the approved real-estate disclaimer wording and original sizing

## Design and responsive behavior
- uses Zenith navy for the primary heading and orange only as a controlled accent
- adds a fine border, soft reflection and restrained shadow to the small label
- keeps the heading on one line at desktop widths and scales it safely on mobile
- changes no form widths, fields or layout behavior

## Scope and protection
- starts from current `main` after PR #132 was merged
- changes only the homepage heading markup and scoped homepage stylesheet
- preserves the estimate form action, methods, field names, validation, reCAPTCHA, disclaimer link, navigation, tracking, structured data and SEO
- confirms balanced CSS braces and no horizontal sizing changes