### PR TITLE
Refine Service Areas into premium landing pages

### DIFF
--- a/css/estimate-form.css
+++ b/css/estimate-form.css
@@ -200,3 +200,180 @@
     flex-basis: 100%;
   }
 }
+
+
+/* Shared estimate form surface
+   The HTML partial loader replaces its placeholder, so the form must be styled
+   by its permanent ID as well as page-level wrappers. Visual-only override. */
+#estimate-form {
+  width: 100%;
+  max-width: 860px;
+  margin: 0 auto;
+  padding: clamp(24px, 3vw, 42px);
+  color: var(--estimate-ink);
+  background:
+    radial-gradient(circle at 94% 3%, rgba(255, 130, 0, .11), transparent 18rem),
+    linear-gradient(145deg, #ffffff, #f8fbfd);
+  border: 1px solid rgba(6, 41, 75, .13);
+  border-radius: 24px;
+  box-shadow: 0 24px 58px rgba(3, 26, 48, .13), inset 0 1px 0 #ffffff;
+  font-family: "Avenir Next", "Manrope", "Segoe UI", Helvetica, Arial, sans-serif;
+}
+
+#estimate-form .form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+#estimate-form .form-group {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+#estimate-form .form-col-6 { flex: 0 0 calc(50% - 8px); }
+#estimate-form .form-col-4 { flex: 0 0 calc(33.333% - 10.7px); }
+
+#estimate-form input,
+#estimate-form select,
+#estimate-form textarea {
+  width: 100%;
+  min-height: 54px;
+  padding: 14px 16px;
+  color: var(--estimate-ink);
+  background: rgba(255, 255, 255, .96);
+  border: 1px solid var(--estimate-line);
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(3, 26, 48, .025);
+  font: inherit;
+  font-size: 16px;
+  line-height: 1.35;
+  transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease;
+}
+
+#estimate-form textarea {
+  min-height: 136px;
+  resize: vertical;
+}
+
+#estimate-form input::placeholder,
+#estimate-form textarea::placeholder {
+  color: #7b8796;
+  opacity: 1;
+}
+
+#estimate-form input:focus,
+#estimate-form select:focus,
+#estimate-form textarea:focus {
+  outline: 0;
+  border-color: var(--estimate-orange);
+  box-shadow: 0 0 0 4px rgba(255, 130, 0, .14), 0 10px 22px rgba(3, 26, 48, .08);
+}
+
+#estimate-form input[type="file"] {
+  padding: 10px;
+  background: #f8fafc;
+}
+
+#estimate-form select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2306294b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 15px center;
+  background-size: 16px;
+  padding-right: 42px;
+}
+
+#estimate-form .zenith-btn {
+  display: block;
+  width: 100%;
+  min-height: 58px;
+  padding: 15px 22px;
+  color: var(--estimate-navy);
+  background: linear-gradient(135deg, #ffb34d 0%, #ff8200 52%, #ed6a00 100%);
+  border: 0;
+  border-radius: 13px;
+  box-shadow: 0 14px 28px rgba(237, 106, 0, .26), inset 0 1px 0 rgba(255, 255, 255, .58);
+  cursor: pointer;
+  font: inherit;
+  font-size: .92rem;
+  font-weight: 850;
+  letter-spacing: .01em;
+  transition: transform .18s ease, box-shadow .18s ease, opacity .18s ease;
+}
+
+#estimate-form .zenith-btn:hover {
+  box-shadow: 0 18px 34px rgba(237, 106, 0, .32), inset 0 1px 0 rgba(255, 255, 255, .65);
+  transform: translateY(-2px);
+}
+
+#estimate-form .zenith-btn:disabled {
+  cursor: not-allowed;
+  opacity: .62;
+  transform: none;
+}
+
+#estimate-form .recaptcha-container {
+  display: flex;
+  justify-content: center;
+  padding: 3px 0;
+}
+
+#estimate-form .form-error-summary {
+  display: none;
+  margin: 0 0 16px;
+  padding: 13px 15px;
+  color: #9f1239;
+  background: #fff7f7;
+  border: 1px solid #fecaca;
+  border-left: 4px solid #ef4444;
+  border-radius: 10px;
+  font-size: .9rem;
+  line-height: 1.5;
+}
+
+#estimate-form.has-errors input:invalid,
+#estimate-form.has-errors select:invalid,
+#estimate-form.has-errors textarea:invalid,
+#estimate-form input:user-invalid,
+#estimate-form select:user-invalid,
+#estimate-form textarea:user-invalid {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, .12);
+}
+
+#estimate-form + .form-disclaimer,
+#estimate-form ~ .form-disclaimer {
+  margin-top: 22px;
+  padding: 15px 0 0;
+  color: var(--estimate-muted);
+  border-top: 1px solid var(--estimate-line);
+  font-size: .74rem;
+  line-height: 1.65;
+}
+
+#estimate-form + .form-disclaimer a,
+#estimate-form ~ .form-disclaimer a {
+  color: var(--estimate-navy-soft);
+  font-weight: 750;
+  text-decoration-color: rgba(255, 130, 0, .75);
+  text-underline-offset: 3px;
+}
+
+@media (max-width: 768px) {
+  #estimate-form {
+    padding: 22px 18px;
+    border-radius: 20px;
+  }
+
+  #estimate-form .form-row {
+    gap: 13px;
+    margin-bottom: 13px;
+  }
+
+  #estimate-form .form-col-6,
+  #estimate-form .form-col-4 {
+    flex-basis: 100%;
+  }
+}

--- a/css/service-area-authority.css
+++ b/css/service-area-authority.css
@@ -53,3 +53,219 @@ html:has(.local-area-page),body.local-area-page{margin:0!important;background:#f
 @media(max-width:960px){.local-jump-nav{top:72px}}
 @media(max-width:680px){.local-jump-nav{top:66px}.local-jump-nav .shell{width:calc(100% - 20px)}.local-condition-note{grid-template-columns:1fr;gap:12px;padding:21px}.local-proof-slot__copy h2,.local-coverage__copy h2{font-size:clamp(2.35rem,10.5vw,3.15rem)}.local-proof-slot__actions{flex-direction:column}.local-proof-slot__actions .button{width:100%}.local-system-guide{border-radius:22px}.local-system-guide__visual img{min-height:260px}.local-system-guide__copy{padding:27px 21px 31px}.local-system-guide h3{font-size:clamp(1.85rem,9vw,2.5rem)}.local-system-guide__copy ul{grid-template-columns:1fr}.local-system-guide__copy .button{width:100%}.local-service-catalog__group summary{min-height:84px;gap:12px;padding:20px}.local-service-catalog__group summary b{font-size:.95rem}.local-service-catalog__group summary em{display:none}.local-service-catalog__group summary::after{width:30px;height:30px;flex:0 0 30px}.local-service-catalog__intro{padding:0 20px 19px}.local-service-catalog__grid{grid-template-columns:1fr}.local-service-catalog__card{min-height:230px;padding:24px 20px}.local-coverage__panel{padding:23px}.local-area-page .interior-trust__grid span:nth-child(3) small{font-size:.55rem}}
 @media(prefers-reduced-motion:reduce){.local-jump-nav{scroll-behavior:auto}.local-project-card,.local-project-card__image img{transition:none}}
+
+/* Landing-page refinement: shared visual language with the asphalt-shingle page.
+   This layer intentionally changes presentation only. */
+.local-area-page {
+  background: var(--mist);
+}
+
+.local-area-page .local-hero {
+  min-height: 720px;
+  display: grid;
+  align-items: center;
+  padding: clamp(78px, 9vw, 126px) 0;
+  background: var(--navy-950);
+}
+
+.local-area-page .local-hero .interior-hero__content {
+  max-width: 1240px;
+}
+
+.local-area-page .local-hero .interior-hero__content h1 {
+  max-width: 860px;
+  font-size: clamp(3.1rem, 5.7vw, 5.65rem) !important;
+  line-height: .98 !important;
+}
+
+.local-area-page .local-hero .interior-hero__content > p {
+  max-width: 735px;
+  font-size: 1.04rem;
+  line-height: 1.78;
+}
+
+.local-area-page .local-hero .interior-hero__shade {
+  background:
+    radial-gradient(circle at 88% 12%, rgba(255,130,0,.18), transparent 27%),
+    linear-gradient(90deg, rgba(3,20,38,.99) 0%, rgba(3,26,48,.95) 46%, rgba(3,26,48,.68) 74%, rgba(3,26,48,.48) 100%),
+    linear-gradient(0deg, rgba(3,26,48,.72), transparent 62%);
+}
+
+.local-jump-nav {
+  top: 102px;
+  width: min(100% - 36px, 1100px);
+  margin: 22px auto 0;
+  color: var(--navy-900);
+  background: rgba(255,255,255,.94);
+  border: 1px solid rgba(6,41,75,.1);
+  border-radius: 16px;
+  box-shadow: var(--shadow-md);
+}
+
+.local-jump-nav .shell {
+  width: 100%;
+  gap: 7px;
+  padding: 10px;
+}
+
+.local-jump-nav a {
+  min-height: 42px;
+  padding: 9px 13px;
+  color: var(--navy-900);
+  border: 0;
+  border-radius: 10px;
+  font-size: .65rem;
+}
+
+.local-jump-nav a:hover,
+.local-jump-nav a:focus-visible {
+  color: #fff;
+  background: var(--navy-900);
+  outline: 0;
+}
+
+.local-area-page .local-section {
+  padding: clamp(80px, 9vw, 128px) 0;
+}
+
+.local-area-page .local-section--mist {
+  background: linear-gradient(180deg, var(--mist), #fff 72%);
+}
+
+.local-heading {
+  max-width: 1180px;
+  gap: clamp(44px, 7vw, 110px);
+  margin-bottom: 54px;
+}
+
+.local-heading h2,
+.local-coverage__copy h2 {
+  font-size: clamp(2.7rem, 4.55vw, 4.75rem);
+  line-height: 1.02;
+}
+
+.local-heading > p {
+  font-size: .98rem;
+  line-height: 1.78;
+}
+
+.local-card-grid {
+  gap: 16px;
+}
+
+.local-card-grid article {
+  min-height: 270px;
+  padding: 32px 28px;
+  border-radius: 20px;
+  box-shadow: 0 16px 38px rgba(3,26,48,.07);
+}
+
+.local-card-grid h3 {
+  margin-top: 36px;
+  font-size: 1.28rem;
+}
+
+.local-condition-note {
+  margin-top: 22px;
+  padding: 27px 30px;
+  border-radius: 18px;
+}
+
+.local-area-page .local-section--navy {
+  background:
+    radial-gradient(circle at 88% 12%, rgba(255,130,0,.16), transparent 28rem),
+    linear-gradient(135deg, var(--navy-950), #082f54);
+}
+
+.local-proof-slot {
+  gap: clamp(50px, 8vw, 116px);
+}
+
+.local-proof-slot__visual {
+  padding: 15px;
+  border-radius: 28px;
+  box-shadow: 0 32px 82px rgba(2,15,29,.44);
+}
+
+.local-proof-slot__visual img {
+  border-radius: 18px;
+}
+
+.local-section--systems {
+  background: #fff;
+}
+
+.local-system-guides {
+  gap: 30px;
+}
+
+.local-system-guide {
+  border-radius: 24px;
+  box-shadow: 0 20px 50px rgba(3,26,48,.09);
+}
+
+.local-system-guide__visual img {
+  min-height: 440px;
+}
+
+.local-system-guide__copy {
+  padding: clamp(34px, 4.8vw, 62px);
+}
+
+.local-system-guide h3 {
+  font-size: clamp(2rem, 3vw, 3.1rem);
+}
+
+.local-service-catalog__group {
+  border-radius: 20px;
+}
+
+.local-service-catalog__group summary {
+  min-height: 84px;
+}
+
+.local-coverage__panel {
+  border-radius: 20px;
+}
+
+.local-area-estimate {
+  padding: clamp(78px, 9vw, 122px) 0;
+  background: #fff;
+}
+
+.local-area-estimate__grid {
+  border-radius: 26px;
+  box-shadow: 0 28px 70px rgba(3,26,48,.2);
+}
+
+.local-cta {
+  background:
+    radial-gradient(circle at 88% 12%, rgba(255,130,0,.16), transparent 28rem),
+    linear-gradient(135deg, var(--navy-950), #082f54);
+}
+
+@media (max-width: 960px) {
+  .local-jump-nav { top: 72px; }
+  .local-area-page .local-hero { min-height: 620px; }
+}
+
+@media (max-width: 680px) {
+  .local-jump-nav {
+    top: 66px;
+    width: calc(100% - 20px);
+    margin-top: 12px;
+  }
+
+  .local-area-page .local-hero {
+    min-height: 590px;
+    padding: 72px 0 84px;
+  }
+
+  .local-area-page .local-hero .interior-hero__content h1 {
+    font-size: clamp(2.85rem, 12vw, 4rem) !important;
+  }
+
+  .local-area-page .local-section { padding: 68px 0; }
+  .local-card-grid article { min-height: auto; padding: 28px 23px; }
+  .local-system-guide__visual img { min-height: 280px; }
+}


### PR DESCRIPTION
Styles the existing Service Area city guides with the same visual language as Zenith’s Asphalt Shingles landing page.

Preserved: all content, forms, tracking, SEO metadata, structured data, links, URLs, and lead-routing behavior.

This follow-up contains only the shared city-page stylesheet refinement.